### PR TITLE
Add display plain

### DIFF
--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -353,12 +353,22 @@ cli.add_command(publish_command)
     is_flag=True,
     help="Ignore git reproducibility checks (not recommended).",
 )
+@click.option(
+    "--display",
+    type=str,
+    # https://github.com/UKGovernmentBEIS/inspect_ai/issues/1891 and
+    # https://github.com/allenai/nora-issues-research/issues/77#issuecomment-2877262319
+    # TODO: remove this once fixed
+    help="Display format. Defaults to plain.",
+    default="plain",
+)
 @click.argument("args", nargs=-1, type=click.UNPROCESSED)
 def eval_command(
     log_dir: str | None,
     config_path: str,
     split: str,
     ignore_git: bool,
+    display: str,
     args: tuple[str],
 ):
     """Run inspect eval-set with arguments and append tasks"""
@@ -379,9 +389,7 @@ def eval_command(
             )
             click.echo(f"No log dir was manually set; using {log_dir}")
     logd_args = ["--log-dir", log_dir]
-    # https://github.com/UKGovernmentBEIS/inspect_ai/issues/1891 and
-    # https://github.com/allenai/nora-issues-research/issues/77#issuecomment-2877262319
-    display_args = ["--display", "plain"]
+    display_args = ["--display", display]
 
     # We use subprocess here to keep arg management simple; an alternative
     # would be calling `inspect_ai.eval_set()` directly, which would allow for


### PR DESCRIPTION
https://github.com/allenai/nora-issues-research/issues/77

Got an issue when running
```
➜  nora-bench git:(main) ✗ uv run norabench eval --solver generate --model openai/gpt-4o --limit 3 --split validation --ignore-git --retry-attempts 1
No log dir was manually set; using ./logs/asta-bench_1.0.0-dev1_validation_2025-05-12T19-10-23
Running /Users/stefanc/code/stefanc-ai2/nora-bench/norabench/config/v1.0.0.yml: inspect eval-set --solver generate --model openai/gpt-4o --limit 3 --retry-attempts 1 --log-dir ./logs/asta-bench_1.0.0-dev1_validation_2025-05-12T19-10-23 norabench/cqa
Traceback (most recent call last):
  File "/Users/stefanc/code/stefanc-ai2/nora-bench/.venv/bin/inspect", line 10, in <module>
    sys.exit(main())
             ^^^^^^
...
                 ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/stefanc/.local/share/uv/python/cpython-3.12.10-macos-aarch64-none/lib/python3.12/asyncio/events.py", line 702, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'MainThread'.
Error: inspect eval-set failed while running /Users/stefanc/code/stefanc-ai2/nora-bench/norabench/config/v1.0.0.yml
```

Looks like somebody else encountered this issue with another eval https://github.com/UKGovernmentBEIS/inspect_ai/issues/1891

@mdarcy220 gave a workaround here https://github.com/allenai/nora-issues-research/issues/77#issuecomment-2877262319

It's bizarre that a text display config can cause asyncio issue... 🤷 

Todo:

- [x] update nora-bench's agent-eval dependency, set the right commit hash https://github.com/allenai/nora-bench/pull/128/files