### PR TITLE
Add required publish command arguments

### DIFF
--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -184,7 +184,7 @@ def score_command(
     click.echo(f"Saved results to {log_dir}/{EVAL_FILENAME}")
     ctx = click.get_current_context()
     click.echo(
-        f"You can now run '{ctx.parent.info_name if ctx.parent else 'cli'} publish {log_dir}' to publish the results"
+        f"You can now run '{ctx.parent.info_name if ctx.parent else 'cli'} publish --agent-name <your-agent-name> --submissions-repo-id <your-submissions-repo-id> --results-repo-id <your-results-repo-id> {log_dir}' to publish the results"
     )
 
 


### PR DESCRIPTION
https://github.com/allenai/nora-issues-research/issues/77

Got this error when doing `norabench publish`
```
Saved results to ./logs/asta-bench_1.0.0-dev1_validation_2025-05-14T00-06-59/agenteval.json
You can now run 'norabench publish ./logs/asta-bench_1.0.0-dev1_validation_2025-05-14T00-06-59' to publish the results
root:/norabench# uv run norabench publish ./logs/asta-bench_1.0.0-dev1_validation_2025-05-14T00-06-59
Usage: norabench publish [OPTIONS] LOG_DIR
Try 'norabench publish --help' for help.

Error: Missing option '--agent-name'.
```

I'll change the message to ask users to add `--agent-name`

For now, Adding random `--agent-name`
```
root:/norabench# uv run norabench publish --agent-name foo ./logs/asta-bench_1.0.0-dev1_validation_2025-05-14T00-06-59
Defaulting username to Hugging Face account: miked-ai
Traceback (most recent call last):
  File "/norabench/.venv/bin/norabench", line 10, in <module>
    sys.exit(cli())
             ^^^^^
  File "/norabench/.venv/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/norabench/.venv/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/norabench/.venv/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/norabench/.venv/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/norabench/.venv/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/norabench/.venv/lib/python3.11/site-packages/agenteval/cli.py", line 308, in publish_command
    logs_url = upload_folder_to_hf(
               ^^^^^^^^^^^^^^^^^^^^
  File "/norabench/.venv/lib/python3.11/site-packages/agenteval/upload.py", line 141, in upload_folder_to_hf
    api.upload_folder(
  File "/norabench/.venv/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 106, in _inner_fn
    validate_repo_id(arg_value)
  File "/norabench/.venv/lib/python3.11/site-packages/huggingface_hub/utils/_validators.py", line 160, in validate_repo_id
    raise HFValidationError(
huggingface_hub.errors.HFValidationError: Repo id must use alphanumeric chars or '-', '_', '.', '--' and '..' are forbidden, '-' and '.' cannot start or end the name, max length is 96: ''.
```

Adding doc/message for required publish args/options