### PR TITLE
Allow None in model costs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.2"
+version = "0.1.3"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -50,7 +50,7 @@ def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float:
             )
             total_cost += prompt_cost + completion_cost
         except Exception as e:
-            total_cost = float("nan")
+            total_cost = None
             logger.warning(
                 f"Problem calculating cost for model {model_usage.model}: {e}"
             )

--- a/src/agenteval/score.py
+++ b/src/agenteval/score.py
@@ -53,7 +53,7 @@ class TaskResult(BaseModel):
     model_usages: list[list[ModelUsageWithName]] | None = None
     """List of model usage lists per sample."""
 
-    model_costs: list[float] | None = None
+    model_costs: list[float | None] | None = None
     """List of model costs per sample."""
 
 


### PR DESCRIPTION
Addresses https://github.com/allenai/nora-issues-research/issues/131

I was able to run this code in isolation and recreate the errors described in the ticket by modifying an `agenteval.json` file, then correct them with the suggested changes.

I can run 'agenteval score' with this code on a sample log directory (used the example from the negative score ticket https://github.com/allenai/nora-issues-research/issues/138).

Will see if I can figure out how to recreate a more full scenario in which these errors originally appeared (handling results from a model not found in litellm)

Would welcome any tips about the protocol for making agent-eval repo changes available in astabench!