### PR TITLE
Make astabench score more resilient to individual failed tasks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.3"
+version = "0.1.4"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
+import sys
 
 import click
 
@@ -153,7 +154,7 @@ def score_command(
         suite_cfg = load_suite_config(config_path)
         eval_result = EvalResult(suite_config=suite_cfg, split=split)
 
-    task_results, eval_specs = process_eval_logs(log_dir)
+    task_results, eval_specs, had_errors = process_eval_logs(log_dir)
     eval_result.eval_specs = eval_specs
     eval_result.results = task_results
 
@@ -177,6 +178,10 @@ def score_command(
     )
     click.echo("Summary statistics:")
     click.echo(json.dumps({k: v.model_dump() for k, v in stats.items()}, indent=2))
+
+    if had_errors:
+        click.echo("Error: Errors occurred while computing some metrics. No scores will be written to `agenteval.json`")
+        sys.exit(1)
 
     # Persist updated EvalResult JSON
     eval_result.save_json(Path(log_dir) / EVAL_FILENAME)

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -391,6 +391,11 @@ def eval_command(
     logd_args = ["--log-dir", log_dir]
     display_args = ["--display", display]
 
+    # Write the config portion of the results file
+    with open(os.path.join(log_dir, EVAL_FILENAME), "w", encoding="utf-8") as f:
+        unscored_eval_config = EvalConfig(suite_config=suite_config, split=split)
+        f.write(unscored_eval_config.model_dump_json(indent=2))
+
     # We use subprocess here to keep arg management simple; an alternative
     # would be calling `inspect_ai.eval_set()` directly, which would allow for
     # programmatic execution
@@ -408,11 +413,6 @@ def eval_command(
         raise click.ClickException(
             f"inspect eval-set failed while running {config_path}"
         )
-
-    # Write the config portion of the results file
-    with open(os.path.join(log_dir, EVAL_FILENAME), "w", encoding="utf-8") as f:
-        unscored_eval_config = EvalConfig(suite_config=suite_config, split=split)
-        f.write(unscored_eval_config.model_dump_json(indent=2))
 
     ctx = click.get_current_context()
     click.echo(

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -392,6 +392,7 @@ def eval_command(
     display_args = ["--display", display]
 
     # Write the config portion of the results file
+    os.makedirs(log_dir, exist_ok=True)
     with open(os.path.join(log_dir, EVAL_FILENAME), "w", encoding="utf-8") as f:
         unscored_eval_config = EvalConfig(suite_config=suite_config, split=split)
         f.write(unscored_eval_config.model_dump_json(indent=2))

--- a/src/agenteval/score.py
+++ b/src/agenteval/score.py
@@ -153,7 +153,7 @@ def process_eval_logs(log_dir: str) -> tuple[list[TaskResult], list[EvalSpec]]:
                 )
             )
         except ValueError as error:
-            logger.warning(f"No metrics for {task_name}: {error}")
+            logger.exception(f"No metrics for {task_name}:")
 
 
     return results, eval_specs

--- a/src/agenteval/score.py
+++ b/src/agenteval/score.py
@@ -98,7 +98,7 @@ def get_normalized_task_name(log: EvalLog) -> str:
     return log.eval.task.split("/")[-1]
 
 
-def process_eval_logs(log_dir: str) -> tuple[list[TaskResult], list[EvalSpec]]:
+def process_eval_logs(log_dir: str) -> tuple[list[TaskResult], list[EvalSpec], bool]:
     """
     Process evaluation logs from a directory and return task results and eval specs.
 
@@ -110,6 +110,7 @@ def process_eval_logs(log_dir: str) -> tuple[list[TaskResult], list[EvalSpec]]:
     """
     # Read evaluation logs
     logs = {}
+    had_errors = False
     for loginfo in list_eval_logs(log_dir):
         log = read_eval_log(loginfo.name, header_only=True)
         task_name = get_normalized_task_name(log)
@@ -153,7 +154,7 @@ def process_eval_logs(log_dir: str) -> tuple[list[TaskResult], list[EvalSpec]]:
                 )
             )
         except ValueError as error:
+            had_errors = True
             logger.exception(f"No metrics for {task_name}:")
-
-
-    return results, eval_specs
+            
+    return results, eval_specs, had_errors


### PR DESCRIPTION
Addresses https://github.com/allenai/nora-issues-research/issues/136 (write agenteval.json before calling inspect) and https://github.com/allenai/nora-issues-research/issues/134 (scoring for successful tasks prevented by ValueError for failed tasks)

Tested with a run in which discovery bench failed and interrupted eval, but other tasks succeeded.

Resulting log dir looks like this; discoverybench log exists but does not contain scores:
```
(astabench) 10:24:21 ~/src/nora-bench learn-to-drive $ ls logs/asta-bench_1.0.0-dev1_validation_2025-06-05T09-04-08/
2025-06-05T09-04-19-07-00_arxivdigestables-validation_JBRKCp28JbjWh5mC2GjAKt.eval	2025-06-05T09-06-04-07-00_discoverybench-validation_6ysF92NugXKkc358GrY2Zs.eval
2025-06-05T09-05-11-07-00_sqa-dev_HLyeQrUAAnLSso732raQ9d.eval				agenteval.json
2025-06-05T09-05-43-07-00_paper-finder-validation_SwiqvPm6Vfn24vb8VcwucF.eval		logs.json
```

running `astabench score` now results in a warning for the task that lacked scores; scores are calculated for the tasks that had them:
```
uv run astabench score logs/asta-bench_1.0.0-dev1_validation_2025-06-05T09-04-08
```

```
No metrics for discoverybench_validation: No scores available in the evaluation log.
Warning: Missing tasks in result set: litqa2_validation, discoverybench_validation, DS-1000, e2e_discovery_validation
Summary statistics:
{
  "overall": {
    "score": null,
    "score_stderr": null,
    "cost": null,
    "cost_stderr": null
  },
  "tag/code": {
    "score": null,
    "score_stderr": null,
    "cost": null,
    "cost_stderr": null
  },
  "tag/lit": {
    "score": null,
    "score_stderr": null,
    "cost": null,
    "cost_stderr": null
  },
  "tag/data": {
    "score": null,
    "score_stderr": null,
    "cost": null,
    "cost_stderr": null
  },
  "tag/discovery": {
    "score": null,
    "score_stderr": null,
    "cost": null,
    "cost_stderr": null
  },
  "task/arxivdigestables_validation": {
    "score": 0.19444444444444442,
    "score_stderr": 0.10015420209622192,
    "cost": 0.021416300000000006,
    "cost_stderr": 0.004915557843215767
  },
  "task/sqa_dev": {
    "score": 0.49404761904761907,
    "score_stderr": 0.09623015873015874,
    "cost": 0.020273333333333334,
    "cost_stderr": 0.0035831446655758183
  },
  "task/litqa2_validation": {
    "score": null,
    "score_stderr": null,
    "cost": null,
    "cost_stderr": null
  },
  "task/paper_finder_validation": {
    "score": 0.030858676207513414,
    "score_stderr": null,
    "cost": 0.020023333333333337,
    "cost_stderr": 0.007007233811886434
  },
  "task/discoverybench_validation": {
    "score": null,
    "score_stderr": null,
    "cost": null,
    "cost_stderr": null
  },
  "task/DS-1000": {
    "score": null,
    "score_stderr": null,
    "cost": null,
    "cost_stderr": null
  },
  "task/e2e_discovery_validation": {
    "score": null,
    "score_stderr": null,
    "cost": null,
    "cost_stderr": null
  }
}
Saved results to logs/asta-bench_1.0.0-dev1_validation_2025-06-05T09-04-08/agenteval.json
```

