### PR TITLE
Correction to cost calculation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.4"
+version = "0.1.5"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -45,8 +45,8 @@ def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float:
         input_tokens = model_usage.usage.input_tokens
         output_tokens = model_usage.usage.output_tokens
         
-        cache_read_input_tokens = model_usage.usage.input_tokens_cache_read
-        cache_write_input_tokens = model_usage.usage.input_tokens_cache_write
+        cache_read_input_tokens = model_usage.usage.input_tokens_cache_read or 0
+        cache_write_input_tokens = model_usage.usage.input_tokens_cache_write or 0
         
 
         try:

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -5,6 +5,7 @@ from logging import getLogger
 from inspect_ai.log import EvalSample, ModelEvent, StepEvent
 from inspect_ai.model import ModelUsage
 from litellm import cost_per_token
+from litellm.types.utils import Usage, PromptTokensDetailsWrapper, PromptTokensDetails
 from pydantic import BaseModel
 
 logger = getLogger(__name__)
@@ -37,24 +38,52 @@ def collect_model_usage(sample: EvalSample) -> list[ModelUsageWithName]:
 def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float:
     """
     Compute aggregate cost for a list of ModelUsageWithName objects.
-    Takes into account cached input tokens through cost_per_token's cache_read_input_tokens parameter.
+    Handles cached tokens via litellm Usage object.
     """
     total_cost = 0.0
     for model_usage in model_usages:
-
-        prompt_tokens = model_usage.usage.input_tokens
-        # anthropic results split total tokens across input, output, cache write, and cache read values
-        if model_usage.usage.total_tokens != prompt_tokens + model_usage.usage.output_tokens:
-            prompt_tokens += (model_usage.usage.input_tokens_cache_write + model_usage.usage.input_tokens_cache_read)
+        input_tokens = model_usage.usage.input_tokens
+        output_tokens = model_usage.usage.output_tokens
         
+        cache_read_input_tokens = model_usage.usage.input_tokens_cache_read
+        # prompt_tokens_details = PromptTokensDetails(cached_tokens=cache_read_input_tokens)
+        
+        cache_write_input_tokens = model_usage.usage.input_tokens_cache_write
+        
+
         try:
+            # input tokens count includes any cached tokens
+            if input_tokens == model_usage.usage.total_tokens - model_usage.usage.output_tokens:
+                text_tokens = input_tokens - cache_read_input_tokens
+                prompt_tokens = input_tokens
+
+            # (anthropic) input tokens count excludes cache read and cache write tokens
+            elif input_tokens == model_usage.usage.total_tokens - output_tokens - cache_read_input_tokens - cache_write_input_tokens:
+                text_tokens = input_tokens
+                prompt_tokens = input_tokens + cache_read_input_tokens + cache_write_input_tokens
+
+            else:
+                raise ValueError(
+                        f"Model usage token counts don't follow expected pattern."
+                    )
+            
+            prompt_tokens_wrapper = PromptTokensDetailsWrapper(cached_tokens=cache_read_input_tokens, text_tokens=text_tokens)
+        
+            litellm_usage = Usage(
+                prompt_tokens=prompt_tokens,
+                completion_tokens=output_tokens,
+                total_tokens=model_usage.usage.total_tokens,
+                reasoning_tokens=model_usage.usage.reasoning_tokens,
+                prompt_tokens_details=prompt_tokens_wrapper,
+                cache_read_input_tokens=cache_read_input_tokens,
+                cache_creation_input_tokens=cache_write_input_tokens
+            )
+            
             prompt_cost, completion_cost = cost_per_token(
                 model=model_usage.model,
-                prompt_tokens=prompt_tokens,
-                completion_tokens=model_usage.usage.output_tokens,
-                cache_read_input_tokens=model_usage.usage.input_tokens_cache_read,
-                cache_creation_input_tokens=model_usage.usage.input_tokens_cache_write,
+                usage_object=litellm_usage,
             )
+
             total_cost += prompt_cost + completion_cost
         except Exception as e:
             total_cost = None

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -46,8 +46,6 @@ def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float:
         output_tokens = model_usage.usage.output_tokens
         
         cache_read_input_tokens = model_usage.usage.input_tokens_cache_read
-        # prompt_tokens_details = PromptTokensDetails(cached_tokens=cache_read_input_tokens)
-        
         cache_write_input_tokens = model_usage.usage.input_tokens_cache_write
         
 

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -47,6 +47,7 @@ def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float:
                 prompt_tokens=model_usage.usage.input_tokens,
                 completion_tokens=model_usage.usage.output_tokens,
                 cache_read_input_tokens=model_usage.usage.input_tokens_cache_read,
+                cache_creation_input_tokens=model_usage.usage.input_tokens_cache_write,
             )
             total_cost += prompt_cost + completion_cost
         except Exception as e:

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -41,13 +41,15 @@ def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float:
     """
     total_cost = 0.0
     for model_usage in model_usages:
+        cache_read_tokens = model_usage.usage.input_tokens_cache_read
+        cache_write_tokens = model_usage.usage.input_tokens_cache_write
         try:
             prompt_cost, completion_cost = cost_per_token(
                 model=model_usage.model,
-                prompt_tokens=model_usage.usage.input_tokens,
+                prompt_tokens=model_usage.usage.input_tokens + cache_read_tokens + cache_write_tokens,
                 completion_tokens=model_usage.usage.output_tokens,
-                cache_read_input_tokens=model_usage.usage.input_tokens_cache_read,
-                cache_creation_input_tokens=model_usage.usage.input_tokens_cache_write,
+                cache_read_input_tokens=cache_read_tokens,
+                cache_creation_input_tokens=cache_write_tokens,
             )
             total_cost += prompt_cost + completion_cost
         except Exception as e:

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -41,15 +41,19 @@ def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float:
     """
     total_cost = 0.0
     for model_usage in model_usages:
-        cache_read_tokens = model_usage.usage.input_tokens_cache_read
-        cache_write_tokens = model_usage.usage.input_tokens_cache_write
+
+        prompt_tokens = model_usage.usage.input_tokens
+        # anthropic results split total tokens across input, output, cache write, and cache read values
+        if model_usage.usage.total_tokens != prompt_tokens + model_usage.usage.output_tokens:
+            prompt_tokens += (model_usage.usage.input_tokens_cache_write + model_usage.usage.input_tokens_cache_read)
+        
         try:
             prompt_cost, completion_cost = cost_per_token(
                 model=model_usage.model,
-                prompt_tokens=model_usage.usage.input_tokens + cache_read_tokens + cache_write_tokens,
+                prompt_tokens=prompt_tokens,
                 completion_tokens=model_usage.usage.output_tokens,
-                cache_read_input_tokens=cache_read_tokens,
-                cache_creation_input_tokens=cache_write_tokens,
+                cache_read_input_tokens=model_usage.usage.input_tokens_cache_read,
+                cache_creation_input_tokens=model_usage.usage.input_tokens_cache_write,
             )
             total_cost += prompt_cost + completion_cost
         except Exception as e:


### PR DESCRIPTION
Addresses https://github.com/allenai/nora-issues-research/issues/138

This change makes two adjustments to how we call litellm.cost_per_token.

First, it includes input_tokens_cache_write as cache_creation_input_tokens.

Second, it includes both cache_read and cache_write tokens as part of the total prompt_tokens.

The LiteLLM code considers total_tokens to be prompt_tokens + continuation_tokens:
from litellm.cost_calculator.cost_per_token:
```
usage_block = Usage(
            prompt_tokens=prompt_tokens,
            completion_tokens=completion_tokens,
            total_tokens=prompt_tokens + completion_tokens,
            cache_creation_input_tokens=cache_creation_input_tokens,
            cache_read_input_tokens=cache_read_input_tokens,
        )
```

For that to match our total_token count, prompt_tokens would need to include both input_tokens_cache_write and input_tokens_cache_read from our usage object:

```
"usage": {
              "input_tokens": 7,
              "output_tokens": 123,
              "total_tokens": 21877,
              "input_tokens_cache_write": 1101,
              "input_tokens_cache_read": 20646,
              "reasoning_tokens": null
            }
```

With these changes, the model costs calculated for the example in the original ticket come out positive:
```
  "model_costs": [
        0.3758097,
        0.2345571,
        0.1014348,
        0.15810795,
        0.17482694999999998,
        0.24655454999999998,
        0.14110215,
        0.20787885,
        0.14684115000000003,
        0.2512665
      ]
```