### PR TITLE
Support weighted macro averages

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ For aggregation in a leaderboard, each task specifies a `primary_metric` as `{sc
 The scoring utils will look for a corresponding stderr metric, 
 by looking for another metric with the same `scorer_name` and with a `metric_name` containing the string "stderr".
 
+### Weighted Macro Averaging with Tags
+
+Tasks can be grouped using `tags` for computing summary statistics. The tags support weighted macro averaging, allowing you to assign different weights to tasks within a tag group.
+
+Tags are specified as simple strings on tasks. To adjust weights for specific tag-task combinations, use the `macro_average_weight_adjustments` field at the split level. Tasks not specified in the adjustments default to a weight of 1.0.
+
+See [sample-config.yml](sample-config.yml) for an example of the tag and weight adjustment format.
+
 ## Score results 
 ```shell
 agenteval score [OPTIONS] LOG_DIR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.6"
+version = "0.1.7"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sample-config.yml
+++ b/sample-config.yml
@@ -8,8 +8,7 @@ splits:
         path: tasks/first_task
         primary_metric: 'my_scorer/my_metric'
         tags:
-          - task1
-
+          - category1
 
   - name: test
     tasks:
@@ -17,4 +16,9 @@ splits:
         path: tasks/second_task
         primary_metric: 'my_scorer/mean'
         tags:
-          - task2
+          - category2
+
+    macro_average_weight_adjustments:
+      - tag: category2
+        task: second_task
+        weight: 0.5  # any other tasks not specified will default to 1.0

--- a/src/agenteval/dataset_features.yml
+++ b/src/agenteval/dataset_features.yml
@@ -18,6 +18,14 @@
         dtype: string
       - name: tags
         sequence: string
+    - name: macro_average_weight_adjustments
+      list:
+      - name: tag
+        dtype: string
+      - name: task
+        dtype: string
+      - name: weight
+        dtype: float64
 - name: split
   dtype: string
 - name: results

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,175 @@
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from agenteval.config import SuiteConfig, Task
+
+
+def test_task_simple_tags():
+    """Test task with simple string tags."""
+    task_data = {
+        "name": "test_task",
+        "path": "tasks/test",
+        "primary_metric": "accuracy/mean",
+        "tags": ["tag1", "tag2"],
+    }
+    task = Task.model_validate(task_data)
+
+    assert task.tags is not None
+    assert len(task.tags) == 2
+    assert task.tags[0] == "tag1"
+    assert task.tags[1] == "tag2"
+
+    # Test helper method
+    assert task.get_tag_names() == ["tag1", "tag2"]
+
+
+def test_task_no_tags():
+    """Test task with no tags."""
+    task_data = {
+        "name": "test_task",
+        "path": "tasks/test",
+        "primary_metric": "accuracy/mean",
+    }
+    task = Task.model_validate(task_data)
+
+    assert task.tags is None
+    assert task.get_tag_names() == []
+
+
+def test_split_weight_adjustments():
+    """Test split with macro_average_weight_adjustments."""
+    split_data = {
+        "name": "test_split",
+        "tasks": [
+            {
+                "name": "task1",
+                "path": "tasks/task1",
+                "primary_metric": "accuracy",
+                "tags": ["category1"],
+            },
+            {
+                "name": "task2",
+                "path": "tasks/task2",
+                "primary_metric": "accuracy",
+                "tags": ["category1"],
+            },
+        ],
+        "macro_average_weight_adjustments": [
+            {"tag": "category1", "task": "task1", "weight": 0.5},
+            {"tag": "category1", "task": "task2", "weight": 2.0},
+        ],
+    }
+
+    from agenteval.config import Split
+
+    split = Split.model_validate(split_data)
+
+    # Test weight lookup
+    assert split.get_macro_average_weight("category1", "task1") == 0.5
+    assert split.get_macro_average_weight("category1", "task2") == 2.0
+
+    # Test default weight for tasks not in adjustments
+    assert split.get_macro_average_weight("category1", "task3") == 1.0
+
+    # Test default weight for tags not in adjustments
+    assert split.get_macro_average_weight("other_tag", "task1") == 1.0
+
+
+def test_split_no_weight_adjustments():
+    """Test split without weight adjustments - should default to 1.0."""
+    split_data = {
+        "name": "test_split",
+        "tasks": [
+            {
+                "name": "task1",
+                "path": "tasks/task1",
+                "primary_metric": "accuracy",
+                "tags": ["category1"],
+            }
+        ],
+    }
+
+    from agenteval.config import Split
+
+    split = Split.model_validate(split_data)
+
+    # Should default to 1.0
+    assert split.get_macro_average_weight("category1", "task1") == 1.0
+    assert split.get_macro_average_weight("any_tag", "any_task") == 1.0
+
+
+def test_suite_config_loading():
+    """Test loading a complete suite config."""
+    config_data = {
+        "name": "test_suite",
+        "version": "1.0.0",
+        "splits": [
+            {
+                "name": "test",
+                "tasks": [
+                    {
+                        "name": "task1",
+                        "path": "tasks/task1",
+                        "primary_metric": "accuracy",
+                        "tags": ["category1"],
+                    }
+                ],
+                "macro_average_weight_adjustments": [
+                    {"tag": "category1", "task": "task1", "weight": 0.5}
+                ],
+            }
+        ],
+    }
+
+    config = SuiteConfig.model_validate(config_data)
+    assert config.name == "test_suite"
+    assert len(config.splits) == 1
+
+    # Test getting tasks and splits
+    tasks = config.get_tasks("test")
+    assert len(tasks) == 1
+    assert tasks[0].name == "task1"
+
+    split = config.get_split("test")
+    assert split.get_macro_average_weight("category1", "task1") == 0.5
+
+
+def test_yaml_loading():
+    """Test loading from YAML format."""
+    yaml_content = """
+name: test_suite
+version: "1.0.0"
+splits:
+  - name: test
+    tasks:
+      - name: task1
+        path: tasks/task1
+        primary_metric: accuracy
+        tags:
+          - category1
+    macro_average_weight_adjustments:
+      - tag: category1
+        task: task1
+        weight: 0.5
+"""
+
+    config_data = yaml.safe_load(yaml_content)
+    config = SuiteConfig.model_validate(config_data)
+
+    assert config.name == "test_suite"
+    split = config.get_split("test")
+    assert split.get_macro_average_weight("category1", "task1") == 0.5
+
+
+def test_invalid_split_name():
+    """Test error when requesting invalid split."""
+    config_data = {"name": "test_suite", "splits": [{"name": "valid", "tasks": []}]}
+
+    config = SuiteConfig.model_validate(config_data)
+
+    with pytest.raises(ValueError, match="Split 'invalid' not found"):
+        config.get_tasks("invalid")
+
+    with pytest.raises(ValueError, match="Split 'invalid' not found"):
+        config.get_split("invalid")

--- a/tests/test_summary_utils.py
+++ b/tests/test_summary_utils.py
@@ -40,3 +40,67 @@ def test_safe_stderr_mixed_with_none():
 
 def test_safe_stderr_empty_list():
     assert _safe_stderr([]) is None
+
+
+def test_safe_mean_with_equal_weights():
+    """Test weighted mean with equal weights should equal regular mean."""
+    values = [1.0, 2.0, 3.0]
+    weights = [1.0, 1.0, 1.0]
+    result = _safe_mean(values, is_score=True, weights=weights)
+    assert result == pytest.approx(2.0)
+
+
+def test_safe_mean_with_different_weights():
+    """Test weighted mean with different weights."""
+    values = [1.0, 2.0, 3.0]
+    weights = [1.0, 2.0, 1.0]
+    # (1*1 + 2*2 + 3*1) / (1+2+1) = 8/4 = 2.0
+    result = _safe_mean(values, is_score=True, weights=weights)
+    assert result == pytest.approx(2.0)
+
+
+def test_safe_mean_weighted_score_with_none():
+    """Test weighted mean for scores treats None as 0."""
+    values = [1.0, None, 3.0]
+    weights = [1.0, 2.0, 1.0]
+    # (1*1 + 0*2 + 3*1) / (1+2+1) = 4/4 = 1.0
+    result = _safe_mean(values, is_score=True, weights=weights)
+    assert result == pytest.approx(1.0)
+
+
+def test_safe_mean_weighted_cost_with_none():
+    """Test weighted mean for costs returns None if any value is None."""
+    values = [1.0, None, 3.0]
+    weights = [1.0, 2.0, 1.0]
+    result = _safe_mean(values, is_score=False, weights=weights)
+    assert result is None
+
+
+def test_safe_mean_weighted_empty():
+    """Test weighted mean with empty lists."""
+    result = _safe_mean([], is_score=True, weights=[])
+    assert result is None
+
+
+def test_safe_mean_weighted_mismatched_lengths():
+    """Test weighted mean with mismatched value/weight lengths raises an error."""
+    values = [1.0, 2.0]
+    weights = [1.0, 2.0, 3.0]
+    with pytest.raises(ValueError, match="Length mismatch"):
+        _safe_mean(values, is_score=True, weights=weights)
+
+
+def test_safe_mean_weighted_zero_weights():
+    """Test weighted mean with zero total weight raises an error."""
+    values = [1.0, 2.0, 3.0]
+    weights = [0.0, 0.0, 0.0]
+    with pytest.raises(ValueError, match="Total weight is zero"):
+        _safe_mean(values, is_score=True, weights=weights)
+
+
+def test_safe_mean_weighted_zero_weights_cost():
+    """Test weighted mean for costs with zero total weight raises an error."""
+    values = [1.0, 2.0, 3.0]
+    weights = [0.0, 0.0, 0.0]
+    with pytest.raises(ValueError, match="Total weight is zero"):
+        _safe_mean(values, is_score=False, weights=weights)


### PR DESCRIPTION
It is looking like we will need the option to adjust the weights in the macro averages, e.g. to define multiple versions of a task (e.g., for search and QA) but avoid over-weighting that task (e.g., by setting weights to 0.5)