### PR TITLE
Don't let null model costs ruin everything

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.9"
+version = "0.1.10"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/leaderboard/upload.py
+++ b/src/agenteval/leaderboard/upload.py
@@ -189,11 +189,16 @@ def compress_model_usages(eval_result: EvalResult):
 
     compressed_results = []
     for task_result in eval_result.results:
+        # replace list[None] with None
+        model_costs = task_result.model_costs
+        if model_costs is not None and all(cost is None for cost in model_costs):
+            model_costs = None
+
         # Create a new TaskResult with compressed model_usages
         compressed_task_result = TaskResult(
             task_name=task_result.task_name,
             metrics=task_result.metrics,
-            model_costs=task_result.model_costs,
+            model_costs=model_costs,
             model_usages=None if task_result.model_usages is None else [],
         )
 


### PR DESCRIPTION
Addresses https://github.com/allenai/nora-issues-research/issues/177

In the case where `astabench score` was unable to return model costs for any problem in a task, this change replaces the resulting list of `None` with `None`.