### PR TITLE
Exclude model usage in scorer spans

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,6 @@ logs/
 .DS_Store
 .mise.toml
 .vscode/
+
+# AI stuff
+CLAUDE.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.13"
+version = "0.1.14"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
https://github.com/allenai/nora-issues-research/issues/216

- Implement two-pass algorithm to properly identify and exclude scorer spans.
- First pass identifies all spans containing ScoreEvents or scorer StepEvents.
- Second pass collects ModelEvents that are not within any scorer span.
- Handles nested spans correctly