### PR TITLE
Handle large results json in cli and ui publish pathways

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.15"
+version = "0.1.16"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -352,11 +352,9 @@ def publish_command(
     click.echo(f"Uploaded submission logs dir to {logs_url}")
     eval_result.submission.logs_url = logs_url
 
-    compressed_usages_result = compress_model_usages(eval_result)
-
     summary_url = upload_summary_to_hf(
         hf_api,
-        compressed_usages_result,
+        eval_result,
         results_repo_id,
         config_name,
         eval_result.split,

--- a/src/agenteval/leaderboard/upload.py
+++ b/src/agenteval/leaderboard/upload.py
@@ -163,7 +163,7 @@ def upload_summary_to_hf(
     _validate_path_component(config_name, "config_name")
     _validate_path_component(split, "split")
     _validate_path_component(submission_name, "submission_name")
-    summary_bytes = BytesIO(eval_result.dump_json_bytes())
+    summary_bytes = BytesIO(eval_result.dump_json_bytes(indent=None))
     api.upload_file(
         path_or_fileobj=summary_bytes,
         path_in_repo=f"{config_name}/{split}/{submission_name}.json",

--- a/src/agenteval/leaderboard/upload.py
+++ b/src/agenteval/leaderboard/upload.py
@@ -163,7 +163,9 @@ def upload_summary_to_hf(
     _validate_path_component(config_name, "config_name")
     _validate_path_component(split, "split")
     _validate_path_component(submission_name, "submission_name")
-    summary_bytes = BytesIO(eval_result.dump_json_bytes(indent=None))
+
+    compressed_result = compress_model_usages(eval_result)
+    summary_bytes = BytesIO(compressed_result.dump_json_bytes(indent=None))
     api.upload_file(
         path_or_fileobj=summary_bytes,
         path_in_repo=f"{config_name}/{split}/{submission_name}.json",

--- a/src/agenteval/leaderboard/upload.py
+++ b/src/agenteval/leaderboard/upload.py
@@ -191,9 +191,9 @@ def compress_model_usages(eval_result: EvalResult):
 
     compressed_results = []
     for task_result in eval_result.results:
-        # replace list[None] with None
+        # replace list[None] with None if any costs are None
         model_costs = task_result.model_costs
-        if model_costs is not None and all(cost is None for cost in model_costs):
+        if model_costs is not None and any(cost is None for cost in model_costs):
             model_costs = None
 
         # Create a new TaskResult with compressed model_usages

--- a/src/agenteval/models.py
+++ b/src/agenteval/models.py
@@ -76,7 +76,7 @@ class EvalResult(EvalConfig):
 
     def dump_json_bytes(
         self,
-        indent: int = 2,
+        indent: int | None = 2,
         **model_dump_kwargs,
     ) -> bytes:
         """


### PR DESCRIPTION
Addresses https://github.com/allenai/astabench-issues/issues/286

1. Publishes compact json summary

This allows larger results files such as @mdarcy220 sweeps to be published to hf results datasets without causing errors in datasets.load_dataset. This changeset retains the compression of model usages by problem but moves it within upload_summary_to_hf.

Tested [here](https://huggingface.co/datasets/allenai/asta-bench-test-results/tree/main/big_cheese) by publishing known problem files with this code and then calling 
`agenteval lb view --repo-id allenai/asta-bench-test-results --config big_cheese --split test` (or validation)

2. Adds more conservative code to sanitize null model costs. Some results from small runs threw errors in data loading because model costs included a mix of nulls and floats (and we were only sanitizing for entirely null results). Created ticket [here](https://github.com/allenai/astabench-issues/issues/296) to explore more nuanced handling.