### PR TITLE
Bypass problematic model costs with custom lookup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.16"
+version = "0.1.17"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/local_cost.py
+++ b/src/agenteval/local_cost.py
@@ -1,11 +1,11 @@
 from litellm.utils import CostPerToken
 
 
-# although these lookups exist in https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
-# calling cost_per_token for these does not return a cost, perhaps due to the associated provider
+# even where these exist in https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
+# calling cost_per_token does not return a cost, perhaps due to the associated provider
 # key represents model name as found in inspect model_usage
 CUSTOM_PRICING = {
-    # costs are for together_ai provider
+    # costs are from https://www.together.ai/pricing
     "meta-llama/Llama-4-Scout-17B-16E-Instruct": CostPerToken(
         input_cost_per_token=1.8e-07, output_cost_per_token=5.9e-07
     ),
@@ -18,8 +18,12 @@ CUSTOM_PRICING = {
     "deepseek-ai/DeepSeek-R1": CostPerToken(
         input_cost_per_token=3e-06, output_cost_per_token=7e-06
     ),
-    # cost is for xai provider
+    # cost is for xai/grok-3 https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
     "grok-3": CostPerToken(
         input_cost_per_token=3e-06, output_cost_per_token=1.5e-05
+    ),
+    # using https://artificialanalysis.ai/models/qwen3-8b-instruct
+    "Qwen3-8B-SciQA-SFT": CostPerToken(
+        input_cost_per_token=1.8e-07, output_cost_per_token=7e-07
     )
 }

--- a/src/agenteval/local_cost.py
+++ b/src/agenteval/local_cost.py
@@ -1,0 +1,25 @@
+from litellm.utils import CostPerToken
+
+
+# although these lookups exist in https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
+# calling cost_per_token for these does not return a cost, perhaps due to the associated provider
+# key represents model name as found in inspect model_usage
+CUSTOM_PRICING = {
+    # costs are for together_ai provider
+    "meta-llama/Llama-4-Scout-17B-16E-Instruct": CostPerToken(
+        input_cost_per_token=1.8e-07, output_cost_per_token=5.9e-07
+    ),
+    "meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8": CostPerToken(
+        input_cost_per_token=2.7e-07, output_cost_per_token=8.5e-07
+    ),
+    "deepseek-ai/DeepSeek-V3": CostPerToken(
+        input_cost_per_token=1.25e-06, output_cost_per_token=1.25e-06
+    ),
+    "deepseek-ai/DeepSeek-R1": CostPerToken(
+        input_cost_per_token=3e-06, output_cost_per_token=7e-06
+    ),
+    # cost is for xai provider
+    "grok-3": CostPerToken(
+        input_cost_per_token=3e-06, output_cost_per_token=1.5e-05
+    )
+}

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -12,8 +12,7 @@ from inspect_ai.log import (
 )
 from inspect_ai.model import ModelUsage
 from litellm import cost_per_token
-from litellm.types.utils import PromptTokensDetails, PromptTokensDetailsWrapper, Usage
-from litellm.utils import CostPerToken
+from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 
 from pydantic import BaseModel
 

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -155,24 +155,24 @@ def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float:
                         f"Model usage token counts don't follow expected pattern."
                     )
 
-            prompt_tokens_wrapper = PromptTokensDetailsWrapper(
-                cached_tokens=cache_read_input_tokens, text_tokens=text_tokens
-            )
+                prompt_tokens_wrapper = PromptTokensDetailsWrapper(
+                    cached_tokens=cache_read_input_tokens, text_tokens=text_tokens
+                )
 
-            litellm_usage = Usage(
-                prompt_tokens=prompt_tokens,
-                completion_tokens=completion_tokens,
-                total_tokens=model_usage.usage.total_tokens,
-                reasoning_tokens=model_usage.usage.reasoning_tokens,
-                prompt_tokens_details=prompt_tokens_wrapper,
-                cache_read_input_tokens=cache_read_input_tokens,
-                cache_creation_input_tokens=cache_write_input_tokens,
-            )
+                litellm_usage = Usage(
+                    prompt_tokens=prompt_tokens,
+                    completion_tokens=completion_tokens,
+                    total_tokens=model_usage.usage.total_tokens,
+                    reasoning_tokens=model_usage.usage.reasoning_tokens,
+                    prompt_tokens_details=prompt_tokens_wrapper,
+                    cache_read_input_tokens=cache_read_input_tokens,
+                    cache_creation_input_tokens=cache_write_input_tokens,
+                )
 
-            prompt_cost, completion_cost = cost_per_token(
-                model=adapt_model_name(model_usage.model),
-                usage_object=litellm_usage,
-            )
+                prompt_cost, completion_cost = cost_per_token(
+                    model=adapt_model_name(model_usage.model),
+                    usage_object=litellm_usage,
+                )
 
             total_cost += prompt_cost + completion_cost
         except Exception as e:


### PR DESCRIPTION
This approach handles some missing costs by translating the model name to something comparable with costs that can be calculated through litellm, and handles remaining cases by providing model costs as custom pricing. This will meet the requirement to provide costs for models run as part of the astabench paper and can be extended for additional models as we finalize results.

Addresses:
https://github.com/allenai/astabench-issues/issues/213
 https://github.com/allenai/astabench-issues/issues/214
https://github.com/allenai/astabench-issues/issues/292

With this change in place, was able to score and get costs for a run with mistral-large-2411:
`agenteval score results/1.0.0-dev1/test/miked-ai_ReAct_2025-07-14T22-10-02` 
```
"task/sqa_test": {
    "score": 0.5116307149163133,
    "score_stderr": 0.026576184938580848,
    "cost": 0.12124798,
    "cost_stderr": 0.03447274104135965
  },
```

And also a run with meta-llama/Llama-4-Scout-17B-16E-Instruct

```
agenteval score results/1.0.0-dev1/test/miked-ai_ReAct_2025-07-11T19-47-37
Summary statistics:
{
  "overall": {
    "score": 0.09942371358900134,
    "score_stderr": null,
    "cost": 0.35320574717341496,
    "cost_stderr": null
  },
  "tag/lit": {
    "score": 0.16971177780890545,
    "score_stderr": null,
    "cost": 0.37962452169278604,
    "cost_stderr": null
  },
  "tag/data": {
    "score": 0.04098093909809391,
    "score_stderr": null,
    "cost": 0.27035231079497907,
    "cost_stderr": null
  },
  "tag/code": {
    "score": 0.03851851851851852,
    "score_stderr": null,
    "cost": 0.11683249465825825,
    "cost_stderr": null
  },
  "tag/discovery": {
    "score": 0.01580528846153846,
    "score_stderr": null,
    "cost": 0.81784517775,
    "cost_stderr": null
  },
  "task/paper_finder_test": {
    "score": 0.022541519425234555,
    "score_stderr": null,
    "cost": 0.1994184616044776,
    "cost_stderr": 0.012131130990985964
  },
  "task/paper_finder_litqa2_test": {
    "score": 0.08,
    "score_stderr": null,
    "cost": 0.19753852906666666,
    "cost_stderr": 0.02591500788292141
  },
  "task/sqa_test": {
    "score": 0.31667200555731567,
    "score_stderr": 0.028897503844362137,
    "cost": 0.3708002312,
    "cost_stderr": 0.03888584762009535
  },
  "task/arxivdigestables_test": {
    "score": 0.11296691958640487,
    "score_stderr": 0.012781983016782383,
    "cost": 0.8380544121,
    "cost_stderr": 0.04570112315614328
  },
  "task/litqa2_test": {
    "score": 0.37333333333333335,
    "score_stderr": 0.056227765041494945,
    "cost": 0.022911434666666668,
    "cost_stderr": 0.004400690529406105
  },
  "task/discoverybench_test": {
    "score": 0.04098093909809391,
    "score_stderr": 0.011218644207395982,
    "cost": 0.27035231079497907,
    "cost_stderr": 0.017865209141965755
  },
  "task/core_bench_test": {
    "score": 0.0,
    "score_stderr": null,
    "cost": 0.05214021810810811,
    "cost_stderr": 0.006876690714938057
  },
  "task/ds1000_test": {
    "score": 0.10444444444444445,
    "score_stderr": 0.01020020951545686,
    "cost": 0.12099180964444445,
    "cost_stderr": 0.003883100115630588
  },
  "task/e2e_discovery_test": {
    "score": 0.017708333333333333,
    "score_stderr": 0.012382595010256701,
    "cost": 0.7792726795,
    "cost_stderr": 0.08516970784938603
  },
  "task/e2e_discovery_hard_test": {
    "score": 0.01390224358974359,
    "score_stderr": 0.008775989616405694,
    "cost": 0.856417676,
    "cost_stderr": 0.07707358221025001
  },
  "task/super_test": {
    "score": 0.011111111111111112,
    "score_stderr": null,
    "cost": 0.17736545622222222,
    "cost_stderr": 0.030974504755948866
  }
}
```