### PR TITLE
Data Separation

### DIFF
--- a/src/agenteval/leaderboard/models.py
+++ b/src/agenteval/leaderboard/models.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel, Field
+
+from ..models import SubmissionMetadata, SuiteConfig, TaskResult
+
+
+class LeaderboardSubmission(BaseModel):
+    suite_config: SuiteConfig
+    """Task configuration for the results."""
+
+    split: str
+    """Split used for the results."""
+
+    results: list[TaskResult] | None = None
+    submission: SubmissionMetadata = Field(default_factory=SubmissionMetadata)

--- a/src/agenteval/leaderboard/schema_generator.py
+++ b/src/agenteval/leaderboard/schema_generator.py
@@ -12,7 +12,7 @@ import yaml
 from datasets import Features
 from pydantic import BaseModel
 
-from ..models import EvalResult
+from .models import LeaderboardSubmission
 
 
 def _pa_type_for_annotation(anno) -> pa.DataType:
@@ -105,7 +105,7 @@ def write_dataset_features(output_path: str) -> None:
     """
     Write the HuggingFace Features data inferred from the EvalResult schema.
     """
-    features = features_from_pydantic(EvalResult)
+    features = features_from_pydantic(LeaderboardSubmission)
     with open(output_path, "w", encoding="utf-8") as f:
         yaml_values = features._to_yaml_list()
         yaml.safe_dump(yaml_values, f, indent=2, sort_keys=False)

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -14,7 +14,7 @@ import seaborn as sns
 
 from .. import compute_summary_statistics
 from ..config import SuiteConfig
-from ..models import EvalResult
+from .models import LeaderboardSubmission
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ class LeaderboardViewer:
         ds = datasets.load_dataset(repo_id, name=config).get(split)
         if not ds:
             raise ValueError(f"Split '{split}' not found in dataset results")
-        suite = EvalResult.model_validate(ds[0]).suite_config
+        suite = LeaderboardSubmission.model_validate(ds[0]).suite_config
         self._cfg = suite
         self.tag_map: dict[str, list[str]] = {}
         for task in suite.get_tasks(split):
@@ -144,7 +144,7 @@ def _get_dataframe(
 
     rows = []
     for itm in ds:
-        ev = EvalResult.model_validate(itm)
+        ev = LeaderboardSubmission.model_validate(itm)
 
         # extract base LLM information
         base_models = set()

--- a/src/agenteval/summary.py
+++ b/src/agenteval/summary.py
@@ -15,6 +15,10 @@ class SummaryStat(BaseModel):
     cost_stderr: float | None
 
 
+class SummaryStats(BaseModel):
+    stats: dict[str, SummaryStat]
+
+
 def _mean(
     vals: Sequence[float], weights: Sequence[float] | None = None
 ) -> float | None:
@@ -64,7 +68,7 @@ def compute_summary_statistics(
     suite_config: SuiteConfig,
     split: str,
     results: list[TaskResult],
-) -> dict[str, SummaryStat]:
+) -> SummaryStats:
     """
     Compute summary statistics for a set of task results.
     """
@@ -153,4 +157,4 @@ def compute_summary_statistics(
         stats[f"tag/{tag}"] = stat
     for task_name, stat in tasks_summary.items():
         stats[f"task/{task_name}"] = stat
-    return stats
+    return SummaryStats(stats=stats)


### PR DESCRIPTION
https://github.com/allenai/astabench-issues/issues/262

Tool modifications for storing internally-computed scores separate from user-submitted data, and separating user-computed data produced by different tool calls.

The main idea is that `eval` and `publish` are run by third-party users, while `score` is run by us, to ensure correctness. Each command produces its own data, without modifying data produced by other commands.

See this [one-pager](https://docs.google.com/document/d/1IDjy1PDhYfh4gjz8r130f3cwy8QXgjLZToSRMOAK13E/edit?usp=sharing)

Key changes:
 - Split `agenteval.json` into components:
   - `eval_config.json` contains suite config and split. Written by `agenteval eval`
   - `scores.json` contains task results extracted from the Inspect logs. Written by `agenteval score`
   - `summary_stats.json` contains suite-level score aggregations. Written by `agenteval score`
   - `submission.json` contains identifying information by the submitting party. Written by `agenteval publish`
 - `agenteval score` accepts a `hf://` URL in place of the log directory
   - If specified, will upload `scores.json` and `summary_stats.json` to the submissions repo, instead of the local log directory
 - `agenteval publish` uploads the log directory to the submissions repo, but does not push data to the leaderboard
 - `agenteval lb publish` accepts a `hf://` URL pointing to the submissions repo and pushes leaderboard data to the results repo
