### PR TITLE
Warn about suite config matches

### DIFF
--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -229,8 +229,15 @@ def score_command(
     if missing_tasks:
         click.echo(f"Warning: Missing tasks in result set: {', '.join(missing_tasks)}")
 
-    # TODO:
-    # warn about missing primary metrics too
+    # warn about missing primary metrics
+    for task_name, metric_info in eval_result.check_result_primary_metrics_against_my_suite_config().items():
+        primary_metric, available_metrics = metric_info
+        warning = (
+            f"Warning: the results for the {task_name} task are missing the primary metric "
+            f"({primary_metric}) according to the summary file's suite config. Available "
+            f"metrics in the results for this task: {', '.join(available_metrics)}."
+        )
+        click.echo(warning)
 
     # Compute and display summary statistics
     stats = compute_summary_statistics(
@@ -378,7 +385,14 @@ def publish_command(
     if maybe_result_repo_suite_config is not None:
         # checking for consistency between the provided summary file's results
         # and the suite config we think represents the results repo
-        # TODO: warn about missing tasks too
+        missing_tasks_according_to_result_repo_suit_config = eval_result.find_missing_tasks_compared_to_other_suite_config(maybe_result_repo_suite_config)
+        if missing_tasks_according_to_result_repo_suit_config:
+            warning = (
+                f"Warning: Tasks in the result repo's suit config that are missing from "
+                f"the results: {', '.join(missing_tasks_according_to_result_repo_suit_config)}"
+            )
+            click.echo(warning)
+
         for task_name, metric_info in eval_result.check_result_primary_metrics_against_provided_suite_config(maybe_result_repo_suite_config).items():
             primary_metric, available_metrics = metric_info
             warning = (

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -141,7 +141,7 @@ def verify_git_reproducibility() -> None:
 
 
 def check_results_against_eval_config(
-    results: TaskResults, eval_config: eval_config, eval_config_origin: str
+    results: TaskResults, eval_config: EvalConfig, eval_config_origin: str
 ):
     # warn about results missing
     if len(results.task_names) == 0:

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -217,7 +217,12 @@ def score_command(
         click.echo(f"Warning: Missing tasks in result set: {', '.join(missing_tasks)}")
 
     # warn about missing primary metrics
-    for task_name, metric_info in task_results.check_primary_metrics_against_provided_eval_config(eval_config).items():
+    for (
+        task_name,
+        metric_info,
+    ) in task_results.check_primary_metrics_against_provided_eval_config(
+        eval_config
+    ).items():
         primary_metric, available_metrics = metric_info
         warning = (
             f"Warning: the results for the {task_name} task are missing the primary metric "
@@ -455,7 +460,9 @@ def publish_lb_command(repo_id: str, submission_url: str):
         if all((os.path.exists(f) for f in required_files)):
             eval_config = read_eval_config(local_submission_path)
             submission = read_submission_metadata(local_submission_path)
-            task_results = TaskResults.model_validate_json(open(local_scores_path).read())
+            task_results = TaskResults.model_validate_json(
+                open(local_scores_path).read()
+            )
 
             # check for consistency between the eval config and results
             # we pulled from the submissions repo
@@ -464,6 +471,7 @@ def publish_lb_command(repo_id: str, submission_url: str):
             # and the suite config from the first row in the results repo
             # (if there's a a first row to find)
             from .leaderboard.view import LeaderboardViewer
+
             maybe_result_repo_first_result = LeaderboardViewer.fetch_first_result_from_result_repo(
                 repo_id=repo_id,
                 # use these values because that's where our new result is going to go
@@ -471,13 +479,17 @@ def publish_lb_command(repo_id: str, submission_url: str):
                 split=eval_config.suite_config.split,
             )
             if maybe_result_repo_first_result is not None:
-                eval_configs_to_check_results_against.append((maybe_result_repo_first_result.to_eval_config(), "result repo"))
+                eval_configs_to_check_results_against.append(
+                    (maybe_result_repo_first_result.to_eval_config(), "result repo")
+                )
 
             for config_tup in eval_configs_to_check_results_against:
                 eval_config_to_check, eval_config_origin = config_tup
 
                 # warn about missing tasks
-                missing_tasks = eval_config_to_check.task_names - task_results.task_names
+                missing_tasks = (
+                    eval_config_to_check.task_names - task_results.task_names
+                )
                 if missing_tasks:
                     warning = (
                         f"Warning: Tasks in the {eval_config_origin}'s suite config that are missing "
@@ -486,7 +498,12 @@ def publish_lb_command(repo_id: str, submission_url: str):
                     click.echo(warning)
 
                 # warn about missing primary metrics
-                for task_name, metric_info in task_results.check_primary_metrics_against_provided_eval_config(eval_config_to_check).items():
+                for (
+                    task_name,
+                    metric_info,
+                ) in task_results.check_primary_metrics_against_provided_eval_config(
+                    eval_config_to_check
+                ).items():
                     primary_metric, available_metrics = metric_info
                     warning = (
                         f"Warning: the results for the {task_name} task are missing the "

--- a/src/agenteval/leaderboard/models.py
+++ b/src/agenteval/leaderboard/models.py
@@ -1,6 +1,6 @@
 from pydantic import BaseModel, Field
 
-from ..models import SubmissionMetadata, SuiteConfig, TaskResult
+from ..models import EvalConfig, SubmissionMetadata, SuiteConfig, TaskResult
 
 
 class LeaderboardSubmission(BaseModel):
@@ -12,3 +12,6 @@ class LeaderboardSubmission(BaseModel):
 
     results: list[TaskResult] | None = None
     submission: SubmissionMetadata = Field(default_factory=SubmissionMetadata)
+
+    def to_eval_config(self) -> EvalConfig:
+        return EvalConfig(suite_config=self.suite_config, split=self.split)

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -44,6 +44,14 @@ class LeaderboardViewer:
             for t in task.tags or []:
                 self.tag_map.setdefault(t, []).append(task.name)
 
+    @staticmethod
+    def fetch_first_result_repo(repo_id: str, huggingface_config: str, split: str) -> Optional[LeaderboardSubmission]:
+        ds = datasets.load_dataset(repo_id, name=huggingface_config).get(split)
+        if ds:
+            return LeaderboardSubmission.model_validate(ds[0])
+        else:
+            return None
+
     def _load(self):
         results = datasets.load_dataset(self._repo_id, name=self._config)
         overview = _get_dataframe(

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -47,7 +47,9 @@ class LeaderboardViewer:
                 self.tag_map.setdefault(t, []).append(task.name)
 
     @staticmethod
-    def fetch_first_result_repo(repo_id: str, huggingface_config: str, split: str) -> Optional[LeaderboardSubmission]:
+    def fetch_first_result_repo(
+        repo_id: str, huggingface_config: str, split: str
+    ) -> Optional[LeaderboardSubmission]:
         ds = datasets.load_dataset(repo_id, name=huggingface_config).get(split)
         if ds is not None:
             return LeaderboardSubmission.model_validate(ds[0])

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -34,10 +34,12 @@ class LeaderboardViewer:
 
         # build suite_config and mapping from tags to tasks from the first result
         # TODO: Verify the sort order
-        ds = datasets.load_dataset(repo_id, name=config).get(split)
-        if not ds:
+        maybe_first_result = LeaderboardViewer.fetch_first_result_repo(
+            repo_id=repo_id, huggingface_config=config, split=split
+        )
+        if maybe_first_result is None:
             raise ValueError(f"Split '{split}' not found in dataset results")
-        suite = LeaderboardSubmission.model_validate(ds[0]).suite_config
+        suite = maybe_first_result.suite_config
         self._cfg = suite
         self.tag_map: dict[str, list[str]] = {}
         for task in suite.get_tasks(split):

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -49,7 +49,7 @@ class LeaderboardViewer:
     @staticmethod
     def fetch_first_result_repo(repo_id: str, huggingface_config: str, split: str) -> Optional[LeaderboardSubmission]:
         ds = datasets.load_dataset(repo_id, name=huggingface_config).get(split)
-        if ds:
+        if ds is not None:
             return LeaderboardSubmission.model_validate(ds[0])
         else:
             return None

--- a/src/agenteval/models.py
+++ b/src/agenteval/models.py
@@ -118,12 +118,3 @@ class TaskResults(BaseModel):
                     available_metrics_for_tasks_missing_primary_metric_by_task_name[task_name] = (primary_metric, result_metric_names)
 
         return available_metrics_for_tasks_missing_primary_metric_by_task_name
-
-    # # TODO: should we use this in view.py too? Probably?
-    # @staticmethod
-    # def fetch_first_result_from_result_repo(repo_id: str, huggingface_config: str, split: str) -> Optional["EvalResult"]:
-    #     ds = datasets.load_dataset(repo_id, name=huggingface_config).get(split)
-    #     if ds:
-    #         return EvalResult.model_validate(ds[0])
-    #     else:
-    #         return None

--- a/src/agenteval/models.py
+++ b/src/agenteval/models.py
@@ -37,15 +37,18 @@ class EvalResult(EvalConfig):
     results: list[TaskResult] | None = None
     submission: SubmissionMetadata = Field(default_factory=SubmissionMetadata)
 
-    def find_missing_tasks(self) -> list[str]:
+    def find_missing_tasks_compared_to_other_suite_config(self, suite_config: SuiteConfig) -> list[str]:
         try:
-            tasks = self.suite_config.get_tasks(self.split)
+            tasks = suite_config.get_tasks(self.split)
             result_task_names = (
                 {result.task_name for result in self.results} if self.results else set()
             )
             return [task.name for task in tasks if task.name not in result_task_names]
         except ValueError:
             return []
+
+    def find_missing_tasks(self) -> list[str]:
+        return self.find_missing_tasks_compared_to_other_suite_config(self.suite_config)
 
     def is_scored(self) -> bool:
         """

--- a/src/agenteval/models.py
+++ b/src/agenteval/models.py
@@ -32,6 +32,12 @@ class SubmissionMetadata(BaseModel):
     tool_usage: str | None = None
 
 
+class SuiteConfigResultsComparisonInfo(BaseModel):
+    tasks_in_only_suite_config: Set[str]
+    tasks_in_only_results: Set[str]
+    available_metrics_for_tasks_missing_primary_metric_in_results: Dict[str, Set[str]]
+
+
 class EvalResult(EvalConfig):
     results: list[TaskResult] | None = None
     submission: SubmissionMetadata = Field(default_factory=SubmissionMetadata)
@@ -87,3 +93,43 @@ class EvalResult(EvalConfig):
             exclude_defaults=False,
             **model_dump_kwargs,
         ).encode("utf-8")
+
+    def check_results_against_provided_suite_config(self, provided_suite_config: SuiteConfig) -> SuiteConfigResultsComparisonInfo:
+        # prep for suite config info
+        tasks_from_suite_config = provided_suite_config.get_tasks(self.split)
+        primary_metric_from_suite_config_by_task_name: Dict[str, str] = {}
+        for task in tasks_from_suite_config:
+            task_name = task.name
+            assert task_name not in primary_metric_from_suite_config_by_task_name
+            primary_metric_from_suite_config_by_task_name[task_name] = task.primary_metric
+
+        # prep for result info
+        task_metric_names_from_results_by_task_name: Dict[str, Set[str]] = {}
+        for result in self.results:
+            task_name = result.task_name
+            if task_name not in task_metric_names_from_results_by_task_name:
+                task_metric_names_from_results_by_task_name[task_name] = set([])
+            for metric in result.metrics:
+                task_metric_names_from_results_by_task_name[task_name].add(metric.name)
+
+        # check tasks
+        task_names_from_suite_config = set(tasks_from_suite_config_by_task_name.keys())
+        task_names_from_results = set(task_metric_names_from_results_by_task_name.keys())
+        tasks_in_suite_config_but_not_in_results = task_names_from_suite_config.difference(task_names_from_results)
+        tasks_in_results_but_not_in_suite_config = task_names_from_results.difference(task_names_from_suite_config)
+
+        # check metrics
+        available_metrics_for_tasks_missing_primary_metric_by_task_name = {}
+        for task_name, primary_metric in primary_metric_from_suite_config_by_task_name.items():
+            result_metric_names = task_metric_names_from_results_by_task_name.get(task_name)
+            if primary_metric not in result_metric_names:
+                available_metrics_for_tasks_missing_primary_metric_by_task_name[task_name] = result_metric_names
+
+        return SuiteConfigResultsComparisonInfo(
+            tasks_in_only_suite_config=tasks_in_suite_config_but_not_in_results,
+            tasks_in_only_results=tasks_in_results_but_not_in_suite_config,
+            available_metrics_for_tasks_missing_primary_metric_in_results=available_metrics_for_tasks_missing_primary_metric_by_task_name,
+        )
+
+    def check_results_against_my_suite_config(self) -> SuiteConfigResultsComparisonInfo:
+        return check_results_against_provided_suite_config(self.suite_config)


### PR DESCRIPTION
Related to https://github.com/allenai/astabench-issues/issues/287. 

The main idea is to warn people about the things that cause errors in `compute_summary_statistics()` or might mean a result doesn't show when you run the view command. I've added these warnings to the `score` command and the `lb publish` command.

Note: should I add something similar to the `publish` command? That would probably mean running at least part of the what the score command runs in there too to get the relevant task results.

For reviewers:
I still want to do a decent chunk of testing, but wanted to get thoughts on if this is generally going in the right direction.