### PR TITLE
Change overall scores to macro average over tags instead of tasks

### DIFF
--- a/src/agenteval/summary.py
+++ b/src/agenteval/summary.py
@@ -137,9 +137,9 @@ def compute_summary_statistics(
             cost_stderr=None,
         )
 
-    # overall summary
-    all_scores = [s.score for s in tasks_summary.values()]
-    all_costs = [s.cost for s in tasks_summary.values()]
+    # overall summary statistics are a macro-average over tag scores
+    all_scores = [s.score for s in tags_summary.values()]
+    all_costs = [s.cost for s in tags_summary.values()]
     overall = SummaryStat(
         score=_safe_mean(all_scores, is_score=True),
         score_stderr=None,


### PR DESCRIPTION
We want the overall scores to be a macro-average over tags since the tags are currently non-overlapping, and we want them to be equal weight despite having different numbers of sub-benchmarks.