### PR TITLE
Preserve EvalSpec when publishing to leaderboard

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.20"
+version = "0.1.21"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/leaderboard/upload.py
+++ b/src/agenteval/leaderboard/upload.py
@@ -197,11 +197,11 @@ def compress_model_usages(eval_result: LeaderboardSubmission):
             model_costs = None
 
         # Create a new TaskResult with compressed model_usages
-        compressed_task_result = TaskResult(
-            task_name=task_result.task_name,
-            metrics=task_result.metrics,
-            model_costs=model_costs,
-            model_usages=None if task_result.model_usages is None else [],
+        compressed_task_result = task_result.model_copy(
+            update={
+                "model_costs": model_costs,
+                "model_usages": None if task_result.model_usages is None else [],
+            }
         )
 
         if task_result.model_usages:


### PR DESCRIPTION
Addresses https://github.com/allenai/astabench-issues/issues/319

After merge/publish will need to bump agenteval in astabench and in leaderboard to include in all publish paths