### PR TITLE
lb publish can handle multiple submissions at once

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.21"
+version = "0.1.22"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
https://github.com/allenai/astabench-issues/issues/262

Accept multiple URLs in `lb publish`. This speeds up rescoring because we can batch upload the results and avoid rate limiting. Also creates a single commit in the Git history

Got rid of the fallback to reading from `agenteval.json` and added a `backfill` command that creates `eval_config.json`, and `scores.json` from the submission repo's `agenteval.json` and creates `submission.json` from the results-repo `agenteval.json`. Used this on a handful of submissions that had been made with an older version of the tool since the last rescoring