### PR TITLE
Populate log_url

### DIFF
--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -532,11 +532,13 @@ def publish_lb_command(repo_id: str, submission_urls: tuple[str, ...]):
 
         # Create results files locally
         for (
+            submission_url,
             submission_path,
             eval_config_path,
             scores_path,
             submission_metadata_path,
         ) in zip(
+            submission_urls,
             submission_paths,
             eval_config_rel_paths,
             scores_rel_paths,
@@ -575,6 +577,7 @@ def publish_lb_command(repo_id: str, submission_urls: tuple[str, ...]):
             submission = SubmissionMetadata.model_validate_json(
                 open(local_submission_path).read()
             )
+            submission.logs_url = submission_url
             lb_submission = LeaderboardSubmission(
                 suite_config=eval_config.suite_config,
                 split=eval_config.split,


### PR DESCRIPTION
https://github.com/allenai/astabench-issues/issues/351

Modify `lb publish` to populate the `log_url` in the results data. The URL is an argument of the `lb publish` command, so this is actually the most definitive value for the URL. in principle, the data could be copied and modified after the user uploads it, so it's best to track exactly where the data was read from when constructing the LB entry.

The HF URL isn't actually specified by the user, so I'm not putting it into the user-uploaded `submission.json` file. Ideally, this field wouldn't even be present in that schema, but we can leave that to our future selves.