### PR TITLE
Logs url matches leaderboard expectations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.26"
+version = "0.1.27"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -500,7 +500,9 @@ def publish_lb_command(repo_id: str, submission_urls: tuple[str, ...]):
 
         # Validate URLs
         for submission_url in submission_urls:
-            submission_repo_id, submission_path = parse_hf_url(submission_url)
+            submission_repo_id, submission_path = parse_hf_url(
+                submission_url
+            )  # validates submission_url format "hf://<repo_id>/<submission_path>"
             submission_repo_ids.add(submission_repo_id)
             submission_paths.append(submission_path)
 
@@ -577,7 +579,7 @@ def publish_lb_command(repo_id: str, submission_urls: tuple[str, ...]):
             submission = SubmissionMetadata.model_validate_json(
                 open(local_submission_path).read()
             )
-            submission.logs_url = submission_url
+            submission.logs_url = submission_url.replace("hf://", "hf://datasets/", 1)
             lb_submission = LeaderboardSubmission(
                 suite_config=eval_config.suite_config,
                 split=eval_config.split,


### PR DESCRIPTION
addresses https://github.com/allenai/astabench-issues/issues/356

I can see the expected output in submission.logs_url here:
allenai/asta-bench-test-results/1.0.0-dev1/test/pclark425_Asta_Panda_2025-08-04T03-40-59.json

& I can load this data with local leaderboard
```
submission: {
submit_time: "2025-08-04T03:40:59.445135Z",
username: "pclark425",
agent_name: "Asta_Panda",
agent_description: "v1.4.7-gpt41",
agent_url: null,
logs_url: "hf://datasets/allenai/asta-bench-internal-submissions/1.0.0-dev1/test/pclark425_Asta_Panda_2025-08-04T03-40-59",
logs_url_public: null,
summary_url: null,
openness: "Open Source",
tool_usage: "Fully Custom"
}
```