### PR TITLE
Fix config key in README check in lb publish

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.30"
+version = "0.1.32"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -579,7 +579,7 @@ def publish_lb_command(repo_id: str, submission_urls: tuple[str, ...]):
             eval_config = EvalConfig.model_validate_json(
                 open(local_eval_config_path).read()
             )
-            config_splits[eval_config.suite_config.name].append(eval_config.split)
+            config_splits[eval_config.suite_config.version].append(eval_config.split)
             results = TaskResults.model_validate_json(
                 open(local_scores_path).read()
             ).results


### PR DESCRIPTION
I think the idea here is, when you're running `lb publish` to compare the suite config in the result to the HF repo's readme. If the suite config has a version name that doesn't correspond to an HF config in the readme, you'll get an error telling you to update the schema first.

But I think there's a little bug where to get the HF config that corresponds to the result's suite config, we're looking at the suite config's name, not its version (when I think what we want to look at is it's version). E.g.

```
Config name ['asta-bench'] not present in hf://allenai/asta-bench-internal-results/README.md
```
('asta-bench' is the name of the relevant suite config, not the version).