### PR TITLE
Update readme fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.33"
+version = "0.1.34"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/leaderboard/models.py
+++ b/src/agenteval/leaderboard/models.py
@@ -97,4 +97,5 @@ class Readme:
             path_in_repo="README.md",
             repo_id=repo_id,
             commit_message=comment,
+            repo_type="dataset",
         )

--- a/src/agenteval/leaderboard/models.py
+++ b/src/agenteval/leaderboard/models.py
@@ -46,7 +46,7 @@ class Readme:
                 "features": self.features._to_yaml_list(),
             }
             configs.append(config_def)
-        yaml_section = yaml.dump({"configs": configs})
+        yaml_section = yaml.dump({"configs": configs}, sort_keys=False)
         return f"---\n{yaml_section.strip()}\n---{self.text_content.lstrip()}"
 
     @staticmethod

--- a/src/agenteval/leaderboard/models.py
+++ b/src/agenteval/leaderboard/models.py
@@ -46,8 +46,8 @@ class Readme:
                 "features": self.features._to_yaml_list(),
             }
             configs.append(config_def)
-        yaml_section = yaml.dump({"configs": configs}, sort_keys=False)
-        return f"---\n{yaml_section.strip()}\n---{self.text_content.lstrip()}"
+        yaml_section = yaml.dump({"configs": configs})
+        return f"---\n{yaml_section.strip()}\n---\n{self.text_content.lstrip()}"
 
     @staticmethod
     def download_and_parse(repo_id: str) -> "Readme":


### PR DESCRIPTION
snippet from the current README:
```
...
  features:
  - name: suite_config
    struct:
    - name: name
      dtype: string
    - name: version
      dtype: string
    - name: splits
      list:
      - name: name
        dtype: string
      - name: tasks
        list:
        - name: name
          dtype: string
        - name: path
          dtype: string
        - name: primary_metric
          dtype: string
        - name: tags
          sequence: string
      - name: macro_average_weight_adjustments
        list:
        - name: tag
          dtype: string
        - name: task
          dtype: string
        - name: weight
          dtype: float64
  - name: split
    dtype: string
...
```

if you do dry-run to update the readme without this change
```
  features:
  - name: suite_config
    struct:
    - dtype: string
      name: name
    - dtype: string
      name: version
    - list:
      - dtype: string
        name: name
      - list:
        - dtype: string
          name: name
        - dtype: string
          name: path
        - dtype: string
          name: primary_metric
        - list: string
          name: tags
        name: tasks
      - list:
        - dtype: string
          name: tag
        - dtype: string
          name: task
        - dtype: float64
          name: weight
        name: macro_average_weight_adjustments
      name: splits
  - dtype: string
    name: split
```

if you do dry-run to update the readme with this change
```
  features:
  - name: suite_config
    struct:
    - name: name
      dtype: string
    - name: version
      dtype: string
    - name: splits
      list:
      - name: name
        dtype: string
      - name: tasks
        list:
        - name: name
          dtype: string
        - name: path
          dtype: string
        - name: primary_metric
          dtype: string
        - name: tags
          list: string
      - name: macro_average_weight_adjustments
        list:
        - name: tag
          dtype: string
        - name: task
          dtype: string
        - name: weight
          dtype: float64
  - name: split
    dtype: string
```

Now that I know what's happening, it's less confusing, but might be nice to keep the old sorting for minimal diffs?

(note I do see a list vs sequence thing too but I think you said that's just packages being out of date)