### PR TITLE
Fix submissions url

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.34"
+version = "0.1.35"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.35"
+version = "0.1.36"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -586,7 +586,11 @@ def publish_lb_command(repo_id: str, submission_urls: tuple[str, ...]):
             submission = SubmissionMetadata.model_validate_json(
                 open(local_submission_path).read()
             )
-            submission.logs_url = submission_url.replace("hf://", "hf://datasets/", 1)
+            if not submission_url.startswith("hf://datasets/"):
+                submission_url_to_use = submission_url.replace("hf://", "hf://datasets/", 1)
+            else:
+                submission_url_to_use = submission_url
+            submission.logs_url = submission_url_to_use
             lb_submission = LeaderboardSubmission(
                 suite_config=eval_config.suite_config,
                 split=eval_config.split,

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -587,7 +587,9 @@ def publish_lb_command(repo_id: str, submission_urls: tuple[str, ...]):
                 open(local_submission_path).read()
             )
             if not submission_url.startswith("hf://datasets/"):
-                submission_url_to_use = submission_url.replace("hf://", "hf://datasets/", 1)
+                submission_url_to_use = submission_url.replace(
+                    "hf://", "hf://datasets/", 1
+                )
             else:
                 submission_url_to_use = submission_url
             submission.logs_url = submission_url_to_use


### PR DESCRIPTION
Related to https://github.com/allenai/astabench-issues/issues/379

My theory is that you get `hf://datasets/datasets/allenai` if you supply a submission url that startswith `hf://datasets/` to lb publish. This PR attempts to fix that.

Testing done:

Before these changes:
```
# agenteval lb publish "hf://datasets/allenai/asta-bench-internal-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07"
...
submissions url to use: hf://datasets/datasets/allenai/asta-bench-internal-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07
...
agenteval lb publish "hf://allenai/asta-bench-internal-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07"
...
submissions url to use: hf://datasets/allenai/asta-bench-internal-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07
```

After these changes:
```
# agenteval lb publish "hf://datasets/allenai/asta-bench-internal-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07"
...
submission url to use: hf://datasets/allenai/asta-bench-internal-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07
...
# agenteval lb publish "hf://allenai/asta-bench-internal-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07"
...
submission url to use: hf://datasets/allenai/asta-bench-internal-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07
```
