### PR TITLE
Freeze model costs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,9 @@ requires-python = ">=3.10"
 dependencies = [
   "click",
   "inspect-ai>=0.3.104",
-  "litellm",
+  # pin litellm so that we know what model costs we're using
+  # see https://github.com/allenai/astabench-issues/issues/391 before changing
+  "litellm==1.75.8",
   "pydantic>=2.0.0",
   # For leaderboard
   "huggingface_hub",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.36"
+version = "0.1.37"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -130,13 +130,9 @@ def verify_git_reproducibility() -> None:
         )
 
 
-def use_local_litellm_model_cost_map():
-    maybe_local_litellm_cost_map = os.getenv("LITELLM_LOCAL_MODEL_COST_MAP")
-    if (maybe_local_litellm_cost_map is not None) and maybe_local_litellm_cost_map != "True":
-        raise click.ClickException("Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to \"True\" before scoring.")
-    elif maybe_local_litellm_cost_map is None:
-        click.echo("Setting LITELLM_LOCAL_MODEL_COST_MAP to \"True\".")
-        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
+def check_using_local_litellm_model_cost_map():
+    if os.getenv("LITELLM_LOCAL_MODEL_COST_MAP") != "True":
+        raise click.ClickException(f'Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to "True" before scoring.')
 
 
 @click.group()
@@ -157,7 +153,7 @@ def score_command(
 ):
     # so that we know what model costs we're using to score
     # more details in https://github.com/allenai/astabench-issues/issues/391
-    use_local_litellm_model_cost_map()
+    check_using_local_litellm_model_cost_map()
 
     hf_url_match = re.match(HF_URL_PATTERN, log_dir)
     temp_dir: tempfile.TemporaryDirectory | None = None

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -133,7 +133,7 @@ def verify_git_reproducibility() -> None:
 def use_local_litellm_model_cost_map():
     maybe_local_litellm_cost_map = os.getenv("LITELLM_LOCAL_MODEL_COST_MAP")
     if (maybe_local_litellm_cost_map is not None) and maybe_local_litellm_cost_map != "True":
-        raise click.ClickException("Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to "True" before scoring.")
+        raise click.ClickException("Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to \"True\" before scoring.")
     elif maybe_local_litellm_cost_map is None:
         click.echo("Setting LITELLM_LOCAL_MODEL_COST_MAP to \"True\".")
         os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -130,6 +130,10 @@ def verify_git_reproducibility() -> None:
         )
 
 
+def check_using_local_litellm_model_cost_map():
+    assert os.getenv("LITELLM_LOCAL_MODEL_COST_MAP") == "True", f"Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to \"True\" before scoring."
+
+
 @click.group()
 def cli():
     pass
@@ -146,6 +150,10 @@ def cli():
 def score_command(
     log_dir: str,
 ):
+    # so that we know what model costs we're using to score
+    # more details in https://github.com/allenai/astabench-issues/issues/391
+    check_using_local_litellm_model_cost_map()
+
     hf_url_match = re.match(HF_URL_PATTERN, log_dir)
     temp_dir: tempfile.TemporaryDirectory | None = None
     if hf_url_match is not None:

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -131,7 +131,9 @@ def verify_git_reproducibility() -> None:
 
 
 def check_using_local_litellm_model_cost_map():
-    assert os.getenv("LITELLM_LOCAL_MODEL_COST_MAP") == "True", f"Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to \"True\" before scoring."
+    assert (
+        os.getenv("LITELLM_LOCAL_MODEL_COST_MAP") == "True"
+    ), f'Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to "True" before scoring.'
 
 
 @click.group()

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -132,7 +132,9 @@ def verify_git_reproducibility() -> None:
 
 def check_using_local_litellm_model_cost_map():
     if os.getenv("LITELLM_LOCAL_MODEL_COST_MAP") != "True":
-        raise click.ClickException(f'Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to "True" before scoring.')
+        raise click.ClickException(
+            f'Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to "True" before scoring.'
+        )
 
 
 @click.group()

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -130,10 +130,13 @@ def verify_git_reproducibility() -> None:
         )
 
 
-def check_using_local_litellm_model_cost_map():
-    assert (
-        os.getenv("LITELLM_LOCAL_MODEL_COST_MAP") == "True"
-    ), f'Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to "True" before scoring.'
+def use_local_litellm_model_cost_map():
+    maybe_local_litellm_cost_map = os.getenv("LITELLM_LOCAL_MODEL_COST_MAP")
+    if (maybe_local_litellm_cost_map is not None) and maybe_local_litellm_cost_map != "True":
+        raise click.ClickException("Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to "True" before scoring.")
+    elif maybe_local_litellm_cost_map is None:
+        click.echo("Setting LITELLM_LOCAL_MODEL_COST_MAP to \"True\".")
+        os.environ["LITELLM_LOCAL_MODEL_COST_MAP"] = "True"
 
 
 @click.group()
@@ -154,7 +157,7 @@ def score_command(
 ):
     # so that we know what model costs we're using to score
     # more details in https://github.com/allenai/astabench-issues/issues/391
-    check_using_local_litellm_model_cost_map()
+    use_local_litellm_model_cost_map()
 
     hf_url_match = re.match(HF_URL_PATTERN, log_dir)
     temp_dir: tempfile.TemporaryDirectory | None = None


### PR DESCRIPTION
Related to the launch blocking part of https://github.com/allenai/astabench-issues/issues/391.

This PR does two things:
1. Pins litellm to 1.75.8
2. Errors if an attempt is made to run the score command without setting `LITELLM_LOCAL_MODEL_COST_MAP` to "True".

LITELLM_LOCAL_MODEL_COST_MAP is documented in https://docs.litellm.ai/docs/completion/token_usage, in the `Don't pull hosted model_cost_map` section. My understanding is that tells the code to use the local model costs map, instead of pulling one on the fly. So combining that with the litellm pin should give us the same model costs I think.

Testing done:

I tried scoring `hf://allenai/asta-bench-internal-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-5-mini_2025-08-11T16-35-18`, pinning litellm to 1.75.8 (what's in this PR) and 1.75.0 (which I think is before a PR adding the GPT-5 family, I think that happened in [1.75.2](https://github.com/BerriAI/litellm/releases/tag/v1.75.2-nightly)). For each version, I tried scoring with and without `LITELLM_LOCAL_MODEL_COST_MAP` set to true...

The following three runs result in the same summary stats:
1.75.0 without `LITELLM_LOCAL_MODEL_COST_MAP` set to true
1.75.8 without `LITELLM_LOCAL_MODEL_COST_MAP` set to true
1.75.8 with `LITELLM_LOCAL_MODEL_COST_MAP` set to true

The 1.75.0 run with `LITELLM_LOCAL_MODEL_COST_MAP` set to true resulted in the same scores in the summary stats file, but no cost info. I also saw errors like the following go by during this run:
```
...
Problem calculating cost for model gpt-5-mini-2025-08-07: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=gpt-5-mini-2025-08-07
 Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers

Provider List: https://docs.litellm.ai/docs/providers

Problem calculating cost for model gpt-5-mini-2025-08-07: litellm.BadRequestError: LLM Provider NOT provided. Pass in the LLM provider you are trying to call. You passed model=gpt-5-mini-2025-08-07
 Pass model as E.g. For 'Huggingface' inference endpoints pass in `completion(model='huggingface/starcoder',..)` Learn more: https://docs.litellm.ai/docs/providers

Provider List: https://docs.litellm.ai/docs/providers
...
```

Note: the two runs without `LITELLM_LOCAL_MODEL_COST_MAP` set to true also initially resulted in an error that looked like this:
```
AssertionError: Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to "True" before scoring.
```
but I commented the relevant check out for the purposes of this testing.

I had also added this snippet to print the hash of the model costs file:
```diff
diff --git a/src/agenteval/cli.py b/src/agenteval/cli.py
index 542bf39..353e580 100644
--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+import hashlib
 import json
 import os
 import re
@@ -154,6 +155,19 @@ def score_command(
     # more details in https://github.com/allenai/astabench-issues/issues/391
     check_using_local_litellm_model_cost_map()

+    # Based on https://github.com/BerriAI/litellm/blob/ef08e18c6641cebc97cb2d9b419d8bb257b25c5c/litellm/litellm_core_utils/get_model_cost_map.py#L16-L28
+    import importlib.resources
+
+    with importlib.resources.path(
+        "litellm", "model_prices_and_context_window_backup.json"
+    ) as cost_one:
+        abs_cost_path = os.path.abspath(cost_one)
+        with open(abs_cost_path, "rb") as cost_two:
+            digest = hashlib.file_digest(cost_two, "sha256")
+
+        cost_file_hash = digest.hexdigest()
+        print(f"cost file hash {cost_file_hash}")
+
     hf_url_match = re.match(HF_URL_PATTERN, log_dir)
     temp_dir: tempfile.TemporaryDirectory | None = None
     if hf_url_match is not None:
```

For 1.75.8: `7831043eb5cf66940315bd893595d6c1b4f4475c281c5c1b19ee59e4ed5f708a` (which is the same thing I recorded during the rescore [here](https://github.com/allenai/astabench-issues/issues/199#issuecomment-3198972811))
For 1.75.0: `c763abf9875919399157e90dafa91d10b5d36145aff328c372315d0e9b7aa175`

We probably can't keep things like this forever - I've left some notes about that [here](https://github.com/allenai/astabench-issues/issues/391#issuecomment-3203784690), but my understanding is that the launch blocking part is just freezing costs for scoring at the current point, and that's all that's handled here.

Summary stats details...

1.75.8, without `LITELLM_LOCAL_MODEL_COST_MAP` set to true...

<details>

```
  "stats": {
    "overall": {
      "score": 0.3148783028247495,
      "score_stderr": null,
      "cost": 0.03517972139633324,
      "cost_stderr": null
    },
    "tag/lit": {
      "score": 0.359073892718989,
      "score_stderr": null,
      "cost": 0.0432097658085206,
      "cost_stderr": null
    },
    "tag/data": {
      "score": 0.2692091729748633,
      "score_stderr": null,
      "cost": 0.011127473221757321,
      "cost_stderr": null
    },
    "tag/code": {
      "score": 0.5052960102960103,
      "score_stderr": null,
      "cost": 0.05169765155505505,
      "cost_stderr": null
    },
    "tag/discovery": {
      "score": 0.12593413530913533,
      "score_stderr": null,
      "cost": 0.034683994999999995,
      "cost_stderr": null
    },
    "task/paper_finder_test": {
      "score": 0.1680882137565247,
      "score_stderr": 0.01736167991412297,
      "cost": 0.0384160127340824,
      "cost_stderr": 0.004496229162562603
    },
    "task/paper_finder_litqa2_test": {
      "score": 0.6133333333333333,
      "score_stderr": 0.05661099544085763,
      "cost": 0.11436817,
      "cost_stderr": 0.017359728699967197
    },
    "task/sqa_test": {
      "score": 0.2672615497644688,
      "score_stderr": 0.03773623587370571,
      "cost": 0.0270534035,
      "cost_stderr": 0.0019422575674411598
    },
    "task/arxivdigestables_test": {
      "score": 0.3209458073549626,
      "score_stderr": 0.016795287448771803,
      "cost": 0.012757592,
      "cost_stderr": 0.000598238094979927
    },
    "task/litqa2_test": {
      "score": 0.7466666666666667,
      "score_stderr": 0.05055844297598726,
      "cost": 0.07485594,
      "cost_stderr": 0.014531272631798089
    },
    "task/discoverybench_test": {
      "score": 0.2692091729748633,
      "score_stderr": 0.024402794451474107,
      "cost": 0.011127473221757321,
      "cost_stderr": 0.0006222390294466313
    },
    "task/core_bench_test": {
      "score": 0.4594594594594595,
      "score_stderr": 0.08305895907471071,
      "cost": 0.04720825405405405,
      "cost_stderr": 0.007319669323511871
    },
    "task/ds1000_test": {
      "score": 0.71,
      "score_stderr": 0.015133811749341808,
      "cost": 0.002989897277777778,
      "cost_stderr": 0.0000549948574693956
    },
    "task/e2e_discovery_test": {
      "score": 0.09482323232323234,
      "score_stderr": 0.03868709687867958,
      "cost": 0.02972574375,
      "cost_stderr": 0.0029628950153995407
    },
    "task/e2e_discovery_hard_test": {
      "score": 0.1570450382950383,
      "score_stderr": 0.04217558424596078,
      "cost": 0.03964224625,
      "cost_stderr": 0.004099116765299048
    },
    "task/super_test": {
      "score": 0.3464285714285715,
      "score_stderr": 0.0673848147211148,
      "cost": 0.10489480333333333,
      "cost_stderr": 0.023534508573437658
    }
  }
}
```

</details>


1.75.8, `LITELLM_LOCAL_MODEL_COST_MAP` to "True":

<details>

```
  "stats": {
    "overall": {
      "score": 0.3148783028247495,
      "score_stderr": null,
      "cost": 0.03517972139633324,
      "cost_stderr": null
    },
    "tag/lit": {
      "score": 0.359073892718989,
      "score_stderr": null,
      "cost": 0.0432097658085206,
      "cost_stderr": null
    },
    "tag/data": {
      "score": 0.2692091729748633,
      "score_stderr": null,
      "cost": 0.011127473221757321,
      "cost_stderr": null
    },
    "tag/code": {
      "score": 0.5052960102960103,
      "score_stderr": null,
      "cost": 0.05169765155505505,
      "cost_stderr": null
    },
    "tag/discovery": {
      "score": 0.12593413530913533,
      "score_stderr": null,
      "cost": 0.034683994999999995,
      "cost_stderr": null
    },
    "task/paper_finder_test": {
      "score": 0.1680882137565247,
      "score_stderr": 0.01736167991412297,
      "cost": 0.0384160127340824,
      "cost_stderr": 0.004496229162562603
    },
    "task/paper_finder_litqa2_test": {
      "score": 0.6133333333333333,
      "score_stderr": 0.05661099544085763,
      "cost": 0.11436817,
      "cost_stderr": 0.017359728699967197
    },
    "task/sqa_test": {
      "score": 0.2672615497644688,
      "score_stderr": 0.03773623587370571,
      "cost": 0.0270534035,
      "cost_stderr": 0.0019422575674411598
    },
    "task/arxivdigestables_test": {
      "score": 0.3209458073549626,
      "score_stderr": 0.016795287448771803,
      "cost": 0.012757592,
      "cost_stderr": 0.000598238094979927
    },
    "task/litqa2_test": {
      "score": 0.7466666666666667,
      "score_stderr": 0.05055844297598726,
      "cost": 0.07485594,
      "cost_stderr": 0.014531272631798089
    },
    "task/discoverybench_test": {
      "score": 0.2692091729748633,
      "score_stderr": 0.024402794451474107,
      "cost": 0.011127473221757321,
      "cost_stderr": 0.0006222390294466313
    },
    "task/core_bench_test": {
      "score": 0.4594594594594595,
      "score_stderr": 0.08305895907471071,
      "cost": 0.04720825405405405,
      "cost_stderr": 0.007319669323511871
    },
    "task/ds1000_test": {
      "score": 0.71,
      "score_stderr": 0.015133811749341808,
      "cost": 0.002989897277777778,
      "cost_stderr": 0.0000549948574693956
    },
    "task/e2e_discovery_test": {
      "score": 0.09482323232323234,
      "score_stderr": 0.03868709687867958,
      "cost": 0.02972574375,
      "cost_stderr": 0.0029628950153995407
    },
    "task/e2e_discovery_hard_test": {
      "score": 0.1570450382950383,
      "score_stderr": 0.04217558424596078,
      "cost": 0.03964224625,
      "cost_stderr": 0.004099116765299048
    },
    "task/super_test": {
      "score": 0.3464285714285715,
      "score_stderr": 0.0673848147211148,
      "cost": 0.10489480333333333,
      "cost_stderr": 0.023534508573437658
    }
  }
}
```

</details>

1.75.0, without `LITELLM_LOCAL_MODEL_COST_MAP` set to true...

<details>

```
  "stats": {
    "overall": {
      "score": 0.3148783028247495,
      "score_stderr": null,
      "cost": 0.03517972139633324,
      "cost_stderr": null
    },
    "tag/lit": {
      "score": 0.359073892718989,
      "score_stderr": null,
      "cost": 0.0432097658085206,
      "cost_stderr": null
    },
    "tag/data": {
      "score": 0.2692091729748633,
      "score_stderr": null,
      "cost": 0.011127473221757321,
      "cost_stderr": null
    },
    "tag/code": {
      "score": 0.5052960102960103,
      "score_stderr": null,
      "cost": 0.05169765155505505,
      "cost_stderr": null
    },
    "tag/discovery": {
      "score": 0.12593413530913533,
      "score_stderr": null,
      "cost": 0.034683994999999995,
      "cost_stderr": null
    },
    "task/paper_finder_test": {
      "score": 0.1680882137565247,
      "score_stderr": 0.01736167991412297,
      "cost": 0.0384160127340824,
      "cost_stderr": 0.004496229162562603
    },
    "task/paper_finder_litqa2_test": {
      "score": 0.6133333333333333,
      "score_stderr": 0.05661099544085763,
      "cost": 0.11436817,
      "cost_stderr": 0.017359728699967197
    },
    "task/sqa_test": {
      "score": 0.2672615497644688,
      "score_stderr": 0.03773623587370571,
      "cost": 0.0270534035,
      "cost_stderr": 0.0019422575674411598
    },
    "task/arxivdigestables_test": {
      "score": 0.3209458073549626,
      "score_stderr": 0.016795287448771803,
      "cost": 0.012757592,
      "cost_stderr": 0.000598238094979927
    },
    "task/litqa2_test": {
      "score": 0.7466666666666667,
      "score_stderr": 0.05055844297598726,
      "cost": 0.07485594,
      "cost_stderr": 0.014531272631798089
    },
    "task/discoverybench_test": {
      "score": 0.2692091729748633,
      "score_stderr": 0.024402794451474107,
      "cost": 0.011127473221757321,
      "cost_stderr": 0.0006222390294466313
    },
    "task/core_bench_test": {
      "score": 0.4594594594594595,
      "score_stderr": 0.08305895907471071,
      "cost": 0.04720825405405405,
      "cost_stderr": 0.007319669323511871
    },
    "task/ds1000_test": {
      "score": 0.71,
      "score_stderr": 0.015133811749341808,
      "cost": 0.002989897277777778,
      "cost_stderr": 0.0000549948574693956
    },
    "task/e2e_discovery_test": {
      "score": 0.09482323232323234,
      "score_stderr": 0.03868709687867958,
      "cost": 0.02972574375,
      "cost_stderr": 0.0029628950153995407
    },
    "task/e2e_discovery_hard_test": {
      "score": 0.1570450382950383,
      "score_stderr": 0.04217558424596078,
      "cost": 0.03964224625,
      "cost_stderr": 0.004099116765299048
    },
    "task/super_test": {
      "score": 0.3464285714285715,
      "score_stderr": 0.0673848147211148,
      "cost": 0.10489480333333333,
      "cost_stderr": 0.023534508573437658
    }
  }
}
```

</details>

1.75.0, With `LITELLM_LOCAL_MODEL_COST_MAP` set to "True":

<details>

```
{
  "stats": {
    "overall": {
      "score": 0.3148783028247495,
      "score_stderr": null,
      "cost": null,
      "cost_stderr": null
    },
    "tag/lit": {
      "score": 0.359073892718989,
      "score_stderr": null,
      "cost": null,
      "cost_stderr": null
    },
    "tag/data": {
      "score": 0.2692091729748633,
      "score_stderr": null,
      "cost": null,
      "cost_stderr": null
    },
    "tag/code": {
      "score": 0.5052960102960103,
      "score_stderr": null,
      "cost": null,
      "cost_stderr": null
    },
    "tag/discovery": {
      "score": 0.12593413530913533,
      "score_stderr": null,
      "cost": null,
      "cost_stderr": null
    },
    "task/paper_finder_test": {
      "score": 0.1680882137565247,
      "score_stderr": 0.01736167991412297,
      "cost": null,
      "cost_stderr": null
    },
    "task/paper_finder_litqa2_test": {
      "score": 0.6133333333333333,
      "score_stderr": 0.05661099544085763,
      "cost": null,
      "cost_stderr": null
    },
    "task/sqa_test": {
      "score": 0.2672615497644688,
      "score_stderr": 0.03773623587370571,
      "cost": null,
      "cost_stderr": null
    },
    "task/arxivdigestables_test": {
      "score": 0.3209458073549626,
      "score_stderr": 0.016795287448771803,
      "cost": null,
      "cost_stderr": null
    },
    "task/litqa2_test": {
      "score": 0.7466666666666667,
      "score_stderr": 0.05055844297598726,
      "cost": null,
      "cost_stderr": null
    },
    "task/discoverybench_test": {
      "score": 0.2692091729748633,
      "score_stderr": 0.024402794451474107,
      "cost": null,
      "cost_stderr": null
    },
    "task/core_bench_test": {
      "score": 0.4594594594594595,
      "score_stderr": 0.08305895907471071,
      "cost": null,
      "cost_stderr": null
    },
    "task/ds1000_test": {
      "score": 0.71,
      "score_stderr": 0.015133811749341808,
      "cost": null,
      "cost_stderr": null
    },
    "task/e2e_discovery_test": {
      "score": 0.09482323232323234,
      "score_stderr": 0.03868709687867958,
      "cost": null,
      "cost_stderr": null
    },
    "task/e2e_discovery_hard_test": {
      "score": 0.1570450382950383,
      "score_stderr": 0.04217558424596078,
      "cost": null,
      "cost_stderr": null
    },
    "task/super_test": {
      "score": 0.3464285714285715,
      "score_stderr": 0.0673848147211148,
      "cost": null,
      "cost_stderr": null
    }
  }
}
```

</details>

