### PR TITLE
Add model name mappings for GPT-5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.36"
+version = "0.1.37"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/leaderboard/model_name_mapping.py
+++ b/src/agenteval/leaderboard/model_name_mapping.py
@@ -15,6 +15,8 @@ LB_MODEL_NAME_MAPPING = {
     "gpt-4.1-nano-2025-04-14": "GPT-4.1 Nano (2025-04)",
     "gpt-4o-2024-11-20": "GPT-4o (2024-11)",
     "codex-mini-latest": "Codex Mini (unpinned)",
+    "gpt-5-2025-08-07": "GPT-5 (2025-08)",
+    "gpt-5-mini-2025-08-07": "GPT-5 Mini (2025-08)",
     # Anthropic models
     "claude-opus-4-20250514": "Claude Opus 4 (2025-05)",
     "claude-sonnet-4-20250514": "Claude Sonnet 4 (2025-05)",


### PR DESCRIPTION
Related to the relevant slack convo.

Note: there are a couple of other things we want to do in this area:
1. For a specific submission, use a different name than what this mapping would produce. 
2. Consolidate model name display adjustments, probably mostly about https://github.com/allenai/asta-bench-leaderboard/blob/1e64d2b6fd0cd9f089c32a652cc6b8df1c3d7cb0/leaderboard_transformer.py#L705. 

This PR doesn't do either of those, I'll handle those separately.

Testing done:

With this change, some relevant entries after doing lb view:
```
                              id                          Agent                                                                          Agent (with models)                                                                                                                          Agent description User/organization Submission date                                                                                                                    Logs                                                           Source                      Openness    Agent tooling                                                                  LLM base  Overall  Overall cost  lit score  lit cost  data score  data cost  code score  code cost  discovery score  discovery cost  Overall frontier  lit frontier  data frontier  code frontier  discovery frontier
...
2025-08-14 18:53:46.954659+00:00               Smolagents Coder                                                           Smolagents Coder (GPT-5 (2025-08))       HuggingFace Smolagents CodeAgent (v1.17.0). This variant uses OpenAI GPT-5 with default reasoning-effort (medium) as the base model.               Ai2      2025-08-14              hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-5_2025-08-14T18-53-46               https://github.com/allenai/asta-bench/tree/038c7bf  Open source & closed weights Custom interface                                                         [GPT-5 (2025-08)] 0.371127      0.127240   0.442604  0.117891    0.267289   0.077001    0.309304   0.095848         0.465313        0.218221              True         False          False           True                True
...
2025-08-14 18:53:01.026721+00:00               Smolagents Coder                                                      Smolagents Coder (GPT-5 Mini (2025-08))  HuggingFace Smolagents CodeAgent (v1.17.0). This variant uses OpenAI GPT-5-mini with default reasoning-effort (medium) as the base model.               Ai2      2025-08-14         hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-5-mini_2025-08-14T18-53-01               https://github.com/allenai/asta-bench/tree/038c7bf  Open source & closed weights Custom interface                                                    [GPT-5 Mini (2025-08)] 0.282295      0.063102   0.350159  0.015214    0.276804   0.071096    0.282674   0.090240         0.219545        0.075860              True          True          False           True               False
```

Without this change:
```
                              id                          Agent                                                                          Agent (with models)                                                                                                                          Agent description User/organization Submission date                                                                                                                    Logs                                                           Source                      Openness    Agent tooling                                                                  LLM base  Overall  Overall cost  lit score  lit cost  data score  data cost  code score  code cost  discovery score  discovery cost  Overall frontier  lit frontier  data frontier  code frontier  discovery frontier
...
2025-08-14 18:53:46.954659+00:00               Smolagents Coder                                                          Smolagents Coder (gpt-5-2025-08-07)       HuggingFace Smolagents CodeAgent (v1.17.0). This variant uses OpenAI GPT-5 with default reasoning-effort (medium) as the base model.               Ai2      2025-08-14              hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-5_2025-08-14T18-53-46               https://github.com/allenai/asta-bench/tree/038c7bf  Open source & closed weights Custom interface                                                        [gpt-5-2025-08-07] 0.371127      0.127240   0.442604  0.117891    0.267289   0.077001    0.309304   0.095848         0.465313        0.218221              True         False          False           True                True
...
2025-08-14 18:53:01.026721+00:00               Smolagents Coder                                                     Smolagents Coder (gpt-5-mini-2025-08-07)  HuggingFace Smolagents CodeAgent (v1.17.0). This variant uses OpenAI GPT-5-mini with default reasoning-effort (medium) as the base model.               Ai2      2025-08-14         hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-5-mini_2025-08-14T18-53-01               https://github.com/allenai/asta-bench/tree/038c7bf  Open source & closed weights Custom interface                                                   [gpt-5-mini-2025-08-07] 0.282295      0.063102   0.350159  0.015214    0.276804   0.071096    0.282674   0.090240         0.219545        0.075860              True          True          False           True               False
```

Relevant bits:
<img width="474" height="335" alt="image" src="https://github.com/user-attachments/assets/f543ce95-96c9-4ec2-818a-8a8807ccd9f4" />
