### PR TITLE
Reproducibility url for multiple revisions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.37"
+version = "0.1.38"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
   "inspect-ai>=0.3.104",
   "litellm",
   "pydantic>=2.0.0",
+  "PyGithub",
   # For leaderboard
   "huggingface_hub",
   "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
   "inspect-ai>=0.3.104",
   "litellm",
   "pydantic>=2.0.0",
-  "PyGithub",
   # For leaderboard
   "huggingface_hub",
   "pyarrow",

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -372,7 +372,7 @@ def construct_reproducibility_url(task_revisions: list[EvalRevision], gh) -> str
     ]
     if len(complete_git_revisions) > 0:
 
-        revs_of_interest: list[GitRevision] = set([])
+        revs_of_interest: set[GitRevision] = set([])
         for revision in complete_git_revisions:
             origin = revision.origin
             commit = revision.commit
@@ -409,7 +409,7 @@ def construct_reproducibility_url(task_revisions: list[EvalRevision], gh) -> str
             source_url = sorted(revs_with_dates, key=lambda r: r.date)[-1].source_url()
         elif len(revs_of_interest) > 0:
             # Try to be somewhat consistent about what gets picked...
-            source_url = sorted(revs_of_interest, key=lambda r: r.commit)[
+            source_url = sorted(list(revs_of_interest), key=lambda r: r.commit)[
                 -1
             ].source_url()
 

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -350,7 +350,9 @@ def get_date_for_commit(repo_name: str, commit_hash: str, gh) -> datetime | None
                 return commit.commit.committer.date
         return None
     except Exception as exc:
-        logger.warning(f"Unable to get date for commit {commit_hash} in {repo_name} ({exc}).")
+        logger.warning(
+            f"Unable to get date for commit {commit_hash} in {repo_name} ({exc})."
+        )
         return None
 
 

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -342,8 +342,6 @@ class GitRevisionWithDate:
 
 
 def get_date_for_commit(repo_name: str, commit_hash: str, gh) -> datetime | None:
-    # test wrong repo
-    # test wrong commit
     try:
         # check rate limiting because otherwise we'll wait for a while
         if gh.rate_limiting[0] > 0:
@@ -412,9 +410,6 @@ def construct_reproducibility_url(task_revisions: list[EvalRevision], gh) -> str
             source_url = sorted(revs_with_dates, key=lambda r: r.date)[-1].source_url()
         elif len(revs_of_interest) > 0:
             source_url = revs_of_interest.pop().source_url()
-
-    # https://github.com/allenai/asta-bench.git
-    # git@github.com:allenai/asta-bench.git
 
     return source_url
 

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -340,7 +340,6 @@ class GitRevisionWithDate:
         return self.revision.source_url()
 
 
-
 def get_date_for_commit(repo_name: str, commit_hash: str, gh) -> datetime | None:
     try:
         # check rate limiting because otherwise we'll wait for a while
@@ -410,7 +409,9 @@ def construct_reproducibility_url(task_revisions: list[EvalRevision], gh) -> str
             source_url = sorted(revs_with_dates, key=lambda r: r.date)[-1].source_url()
         elif len(revs_of_interest) > 0:
             # Try to be somewhat consistent about what gets picked...
-            source_url = sorted(revs_of_interest, key=lambda r: r.commit)[-1].source_url()
+            source_url = sorted(revs_of_interest, key=lambda r: r.commit)[
+                -1
+            ].source_url()
 
     return source_url
 

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -379,8 +379,6 @@ def construct_reproducibility_url(task_revisions: list[EvalRevision], gh) -> str
             if origin.startswith("git@"):
                 # Convert git@github.com:user/repo.git to https://github.com/user/repo
                 origin = origin.replace(":", "/", 1).replace("git@", "https://")
-                # git@github.com:allenai/asta-bench.git
-                # no: https///github.com:allenai/asta-bench
 
             # Remove .git suffix if present
             if origin.endswith(".git"):

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -4,7 +4,6 @@ View and plot leaderboard results.
 
 import logging
 from dataclasses import dataclass
-from datetime import datetime
 from typing import Literal
 from zoneinfo import ZoneInfo
 

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -409,7 +409,8 @@ def construct_reproducibility_url(task_revisions: list[EvalRevision], gh) -> str
         if len(revs_with_dates) > 0:
             source_url = sorted(revs_with_dates, key=lambda r: r.date)[-1].source_url()
         elif len(revs_of_interest) > 0:
-            source_url = revs_of_interest.pop().source_url()
+            # Try to be somewhat consistent about what gets picked...
+            source_url = sorted(revs_of_interest, key=lambda r: r.commit)[-1].source_url()
 
     return source_url
 

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -346,11 +346,11 @@ def get_date_for_commit(repo_name: str, commit_hash: str, gh) -> datetime | None
         if gh.rate_limiting[0] > 0:
             repo = gh.get_repo(repo_name)
             if gh.rate_limiting[0] > 0:
-                commit = r.get_commit(commit_hash)
-                return c.commit.committer.date
+                commit = repo.get_commit(commit_hash)
+                return commit.commit.committer.date
         return None
     except Exception as exc:
-        logger.warning(f"Unable to get date for commit {commit_hash} in {repo_name}.")
+        logger.warning(f"Unable to get date for commit {commit_hash} in {repo_name} ({exc}).")
         return None
 
 


### PR DESCRIPTION
Related to https://github.com/allenai/astabench-issues/issues/342.

The current code creates a source url when there's only one revision in a result. We'd like to have source urls when we have more than one revision...

It sounds like ideally we'd like like to show all the source urls we can make off revisions (see [this](https://github.com/allenai/astabench-issues/issues/342#issuecomment-3204220872)). But I imagine there's some design that has to go in there (is it a new column, what is called, where does it go). So this PR creates one source URL when we can create multiple, to tide us over until we know what we want for showing multiple.

Note: it's possible we could get a different source url if we get rate-limited during one instance of the leaderboard coming up, and don't the next. Maybe we should just take out the date sorting altogether and sort alphabetically (until we show all of them)?

Testing done:

I ran lb view and printed out source URLs for submissions for the test split in the new leaderboard.

Without these changes:

<details>

```
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis_2025-08-06T00-31-24
	https://github.com/allenai/asta-bench/tree/50bb9fd
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis_2025-08-14T19-41-03
	https://github.com/allenai/asta-bench/tree/50bb9fd
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis_2025-08-15T21-26-33
	https://github.com/allenai/asta-bench/tree/50bb9fd
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__Flash-2.5__2025-07-11T21-59-16
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__GPT-4.1__2025-07-11T21-23-03
	https://github.com/allenai/asta-bench/tree/3e617e8
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__Haiku-3.5__2025-07-13T22-40-44
	https://github.com/allenai/asta-bench/tree/50bb9fd
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__Pro-2.5__2025-07-12T06-06-53
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__Sonnet_4.0__2025-07-11T21-22-47
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__o3__2025-07-12T08-01-00
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Asta_Scholar_QA_2025-07-11T19-45-30
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Asta_Scholar_QA_2025-07-23T22-30-16
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Asta_Scholar_QA__No_Tables__2025-07-23T22-38-03
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Elicit_2025-07-23T22-03-55
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_FutureHouse_CROW_2025-07-26T17-30-59
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_FutureHouse_FALCON_2025-07-26T17-31-12
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_OpenSciLM_2025-08-14T22-49-08
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Perplexity_Deep_Research_2025-08-08T22-04-18
	https://github.com/nbalepur/personalized-asta-bench/tree/98b6cc2
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aryeh_tiktinsky_ai2_Asta_Paper_Finder_2025-08-07T19-03-14
	https://github.com/allenai/asta-bench/tree/ca5b0ad
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aryeh_tiktinsky_ai2_You.com_Search_API_2025-08-07T18-53-46
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/danyhai2_OpenAI_Deep_Research_2025-07-26T02-23-12
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/danyhai2_STORM_2025-07-26T02-22-14
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/danyhai2_Scispace_2025-07-26T02-23-45
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/danyhai2_You.com_Research_API_2025-08-04T14-34-12
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta-v0_2025-08-14T02-11-03
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta_Code_2025-08-01T16-42-22
	https://github.com/allenai/asta-bench/tree/e339cf6
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta_Code_2025-08-01T16-42-47
	https://github.com/allenai/asta-bench/tree/e339cf6
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta_Code_GPT-5-mini_2025-08-14T19-04-57
	https://github.com/allenai/asta-bench/tree/be252e2
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta_Code_GPT-5_2025-08-14T19-05-55
	https://github.com/allenai/asta-bench/tree/be252e2
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-Claude-3.5-Haiku_2025-08-08T15-59-56
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-Claude-Sonnet-4_2025-08-08T16-00-10
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-4.1_2025-08-08T16-00-51
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-4o_2025-08-08T16-01-09
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-5-mini_2025-08-11T16-35-18
	https://github.com/allenai/asta-bench/tree/f7e2539
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-5_2025-08-11T16-34-47
	https://github.com/allenai/asta-bench/tree/f7e2539
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-Gemini-2.5-Flash_2025-08-08T16-00-31
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-Llama-4-Scout_2025-08-08T15-59-30
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-o3_2025-08-08T16-01-22
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-Claude-3.5-Haiku_2025-08-08T15-57-42
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-Claude-Sonnet-4_2025-08-08T15-58-04
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-4.1_2025-08-08T15-59-03
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-4o_2025-08-08T16-08-41
	https://github.com/allenai/asta-bench/tree/4873edf
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-5-mini_2025-08-14T18-53-01
	https://github.com/allenai/asta-bench/tree/038c7bf
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-5_2025-08-14T18-53-46
	https://github.com/allenai/asta-bench/tree/038c7bf
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-Gemini-2.5-Flash_2025-08-08T15-58-36
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-Llama-4-Scout_2025-08-08T15-57-17
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_CodeScientist_2025-07-10T18-28-47
	https://github.com/allenai/asta-bench/tree/52aeb97
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T05-07-21
	https://github.com/allenai/asta-bench/tree/d11c4e9
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T19-49-10
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T21-25-51
	https://github.com/openlocus/asta-bench/tree/ae8b47f
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T21-31-12
	https://github.com/openlocus/asta-bench/tree/ae8b47f
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T21-39-55
	https://github.com/openlocus/asta-bench/tree/4d95eb7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_Panda_2025-08-04T03-35-11
	https://github.com/allenai/asta-bench/tree/c45780e
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_Panda_2025-08-04T03-40-59
	https://github.com/allenai/asta-bench/tree/c45780e
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Faker_2025-07-10T18-34-10
	https://github.com/allenai/asta-bench/tree/52aeb97
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA_2025-08-08T18-04-13
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA_2025-08-08T23-09-48
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07
	None
```

</details>

With these changes:

<details>

```
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis_2025-08-06T00-31-24
	https://github.com/allenai/asta-bench/tree/50bb9fd
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis_2025-08-14T19-41-03
	https://github.com/allenai/asta-bench/tree/50bb9fd
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis_2025-08-15T21-26-33
	https://github.com/allenai/asta-bench/tree/50bb9fd
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__Flash-2.5__2025-07-11T21-59-16
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__GPT-4.1__2025-07-11T21-23-03
	https://github.com/allenai/asta-bench/tree/3e617e8
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__Haiku-3.5__2025-07-13T22-40-44
	https://github.com/allenai/asta-bench/tree/50bb9fd
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__Pro-2.5__2025-07-12T06-06-53
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__Sonnet_4.0__2025-07-11T21-22-47
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aakanksha19_Asta_Table_Synthesis__o3__2025-07-12T08-01-00
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Asta_Scholar_QA_2025-07-11T19-45-30
	https://github.com/allenai/asta-bench/tree/63ed323
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Asta_Scholar_QA_2025-07-23T22-30-16
	https://github.com/allenai/asta-bench/tree/e930cde
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Asta_Scholar_QA__No_Tables__2025-07-23T22-38-03
	https://github.com/allenai/asta-bench/tree/e930cde
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Elicit_2025-07-23T22-03-55
	https://github.com/allenai/asta-bench/tree/d1b8faa
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_FutureHouse_CROW_2025-07-26T17-30-59
	https://github.com/allenai/asta-bench/tree/e930cde
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_FutureHouse_FALCON_2025-07-26T17-31-12
	https://github.com/allenai/asta-bench/tree/e930cde
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_OpenSciLM_2025-08-14T22-49-08
	https://github.com/allenai/asta-bench/tree/f7e2539
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aps6992_Perplexity_Deep_Research_2025-08-08T22-04-18
	https://github.com/nbalepur/personalized-asta-bench/tree/98b6cc2
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aryeh_tiktinsky_ai2_Asta_Paper_Finder_2025-08-07T19-03-14
	https://github.com/allenai/asta-bench/tree/ca5b0ad
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/aryeh_tiktinsky_ai2_You.com_Search_API_2025-08-07T18-53-46
	https://github.com/allenai/asta-bench/tree/ce99d55
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/danyhai2_OpenAI_Deep_Research_2025-07-26T02-23-12
	https://github.com/allenai/asta-bench/tree/4ff64a1
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/danyhai2_STORM_2025-07-26T02-22-14
	https://github.com/allenai/asta-bench/tree/4ff64a1
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/danyhai2_Scispace_2025-07-26T02-23-45
	https://github.com/allenai/asta-bench/tree/4ff64a1
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/danyhai2_You.com_Research_API_2025-08-04T14-34-12
	https://github.com/allenai/asta-bench/tree/63ed323
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta-v0_2025-08-14T02-11-03
	https://github.com/allenai/asta-bench/tree/f507043
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta_Code_2025-08-01T16-42-22
	https://github.com/allenai/asta-bench/tree/e339cf6
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta_Code_2025-08-01T16-42-47
	https://github.com/allenai/asta-bench/tree/e339cf6
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta_Code_GPT-5-mini_2025-08-14T19-04-57
	https://github.com/allenai/asta-bench/tree/be252e2
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Asta_Code_GPT-5_2025-08-14T19-05-55
	https://github.com/allenai/asta-bench/tree/be252e2
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-Claude-3.5-Haiku_2025-08-08T15-59-56
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-Claude-Sonnet-4_2025-08-08T16-00-10
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-4.1_2025-08-08T16-00-51
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-4o_2025-08-08T16-01-09
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-5-mini_2025-08-11T16-35-18
	https://github.com/allenai/asta-bench/tree/f7e2539
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-5_2025-08-11T16-34-47
	https://github.com/allenai/asta-bench/tree/f7e2539
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-Gemini-2.5-Flash_2025-08-08T16-00-31
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-Llama-4-Scout_2025-08-08T15-59-30
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_ReAct-o3_2025-08-08T16-01-22
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-Claude-3.5-Haiku_2025-08-08T15-57-42
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-Claude-Sonnet-4_2025-08-08T15-58-04
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-4.1_2025-08-08T15-59-03
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-4o_2025-08-08T16-08-41
	https://github.com/allenai/asta-bench/tree/4873edf
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-5-mini_2025-08-14T18-53-01
	https://github.com/allenai/asta-bench/tree/038c7bf
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-GPT-5_2025-08-14T18-53-46
	https://github.com/allenai/asta-bench/tree/038c7bf
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-Gemini-2.5-Flash_2025-08-08T15-58-36
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/miked-ai_Smolagents-Llama-4-Scout_2025-08-08T15-57-17
	https://github.com/allenai/asta-bench/tree/99eb7c7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_CodeScientist_2025-07-10T18-28-47
	https://github.com/allenai/asta-bench/tree/52aeb97
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T05-07-21
	https://github.com/allenai/asta-bench/tree/d11c4e9
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T19-49-10
	None
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T21-25-51
	https://github.com/openlocus/asta-bench/tree/ae8b47f
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T21-31-12
	https://github.com/openlocus/asta-bench/tree/ae8b47f
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_DataVoyager_2025-08-14T21-39-55
	https://github.com/openlocus/asta-bench/tree/4d95eb7
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_Panda_2025-08-04T03-35-11
	https://github.com/allenai/asta-bench/tree/c45780e
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Asta_Panda_2025-08-04T03-40-59
	https://github.com/allenai/asta-bench/tree/c45780e
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/pclark425_Faker_2025-07-10T18-34-10
	https://github.com/allenai/asta-bench/tree/52aeb97
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA_2025-08-08T18-04-13
	https://github.com/allenai/asta-bench/tree/7d9531a
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA_2025-08-08T23-09-48
	https://github.com/allenai/asta-bench/tree/7d9531a
hf://datasets/allenai/asta-bench-submissions/1.0.0-dev1/test/varshak1_Asta_Scholar_QA__No_Tables__2025-08-13T00-17-07
	https://github.com/allenai/asta-bench/tree/7d9531a
```

</details>