### PR TITLE
Cost freezing take two

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -44,3 +44,10 @@ When a new config version is defined (e.g. v1.1.0), you need to update the HF sc
 python scripts/update_readme.py add-config --config-name <config_name> --split <split1> --split <split2> ...
 ```
 The script will enforce that all config versions use the same data model for leaderboard submissions.
+
+
+# Bumping litellm
+
+We do a couple of things in an effort to compute costs for things in a consistent way. One of these things is putting limits on the litellm version used (more details [here](https://github.com/allenai/astabench-issues/issues/391)).
+
+If you need to bump litellm, please also update the version of the `model_prices_and_context_window_backup.json` file we point to in `prep_litellm_cost_map()` in [cli.py](./src/agenteval/cli.py) to the version in the version of litellm you want to bump to (if you want a range, use the version from the upper limit). To do that, find the relevant release in the litellm repo, grab the corresponding SHA, and use it in `desired_model_costs_url`. In some cases, it may be desirable to rescore all the results of interest after doing this. More on this coming later.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.39"
+version = "0.1.40"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "inspect-ai>=0.3.104",
   # pin litellm so that we know what model costs we're using
   # see https://github.com/allenai/astabench-issues/issues/391 before changing
-  "litellm==1.75.8",
+  "litellm<=1.75.8",
   "pydantic>=2.0.0",
   # For leaderboard
   "huggingface_hub",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
   "click",
   "inspect-ai>=0.3.104",
   # pin litellm so that we know what model costs we're using
-  # see https://github.com/allenai/astabench-issues/issues/391 before changing
+  # see the Development.md doc before changing
   "litellm==1.68.0",
   "pydantic>=2.0.0",
   # For leaderboard

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "inspect-ai>=0.3.104",
   # pin litellm so that we know what model costs we're using
   # see https://github.com/allenai/astabench-issues/issues/391 before changing
-  "litellm<=1.75.8",
+  "litellm==1.68.0",
   "pydantic>=2.0.0",
   # For leaderboard
   "huggingface_hub",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "inspect-ai>=0.3.104",
   # pin litellm so that we know what model costs we're using
   # see the Development.md doc before changing
-  "litellm==1.68.0",
+  "litellm==1.67.4.post1",
   "pydantic>=2.0.0",
   # For leaderboard
   "huggingface_hub",

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -160,9 +160,7 @@ def prep_litellm_cost_map():
     desired_model_costs_keys = set(desired_model_costs.keys())
     in_current_not_in_desired = current_model_cost_keys - desired_model_costs_keys
     if len(in_current_not_in_desired) > 0:
-        raise click.ClickException(
-            f"Info for {in_current_not_in_desired} is available but not from the specified cost map!"
-        )
+        click.echo(f"WARNING: Info for {in_current_not_in_desired} is available but not from the specified cost map!")
 
     register_model(model_cost=desired_model_costs)
 

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -149,10 +149,9 @@ def prep_litellm_cost_map():
     # So we'll load the cost file we want ourselves from the URL, and pass its info in as a dict.
     # This snippet is mostly lifted from
     # https://github.com/BerriAI/litellm/blob/b9621c760d3355e06dd17ec89b9eb6776755392e/litellm/litellm_core_utils/get_model_cost_map.py#L16
-    response = httpx.get(
-        "https://raw.githubusercontent.com/BerriAI/litellm/eb66daeef740947c0326826817cf68fb56a8b931/litellm/model_prices_and_context_window_backup.json",
-        timeout=5,
-    )
+    # See the Development.md before changing.
+    desired_model_costs_url = "https://raw.githubusercontent.com/BerriAI/litellm/eb66daeef740947c0326826817cf68fb56a8b931/litellm/model_prices_and_context_window_backup.json"
+    response = httpx.get(desired_model_costs_url, timeout=5)
     response.raise_for_status()
     desired_model_costs = response.json()
 
@@ -198,7 +197,7 @@ def score_command(
     log_dir: str,
 ):
     # so that we know what model costs we're using to score
-    # more details in https://github.com/allenai/astabench-issues/issues/391
+    # more details in the Development.md
     prep_litellm_cost_map()
 
     hf_url_match = re.match(HF_URL_PATTERN, log_dir)

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-import json
 import hashlib
+import json
 import os
 import re
 import subprocess
@@ -13,7 +13,8 @@ from io import BytesIO
 import click
 import datasets
 import httpx
-from litellm import model_cost as litellm_model_cost, register_model
+from litellm import model_cost as litellm_model_cost
+from litellm import register_model
 
 from agenteval.leaderboard.schema_generator import load_dataset_features
 
@@ -148,7 +149,8 @@ def prep_litellm_cost_map():
     # This snippet is mostly lifted from
     # https://github.com/BerriAI/litellm/blob/b9621c760d3355e06dd17ec89b9eb6776755392e/litellm/litellm_core_utils/get_model_cost_map.py#L16
     response = httpx.get(
-        "https://raw.githubusercontent.com/BerriAI/litellm/eb66daeef740947c0326826817cf68fb56a8b931/litellm/model_prices_and_context_window_backup.json", timeout=5
+        "https://raw.githubusercontent.com/BerriAI/litellm/eb66daeef740947c0326826817cf68fb56a8b931/litellm/model_prices_and_context_window_backup.json",
+        timeout=5,
     )
     response.raise_for_status()
     desired_model_costs = response.json()
@@ -158,7 +160,9 @@ def prep_litellm_cost_map():
     desired_model_costs_keys = set(desired_model_costs.keys())
     in_current_not_in_desired = current_model_cost_keys - desired_model_costs_keys
     if len(in_current_not_in_desired) > 0:
-        raise click.ClickException(f"Info for {in_current_not_in_desired} is available but not from the specified cost map!")
+        raise click.ClickException(
+            f"Info for {in_current_not_in_desired} is available but not from the specified cost map!"
+        )
 
     register_model(model_cost=desired_model_costs)
 

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -169,6 +169,7 @@ def prep_litellm_cost_map():
     h = hashlib.sha256()
     h.update(json.dumps(litellm_model_cost, sort_keys=True).encode())
     model_cost_hash = h.hexdigest()
+    click.echo(f"litellm version: {litellm.__version__}")
     click.echo(f"Model costs hash {model_cost_hash}.")
 
 

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -160,7 +160,9 @@ def prep_litellm_cost_map():
     desired_model_costs_keys = set(desired_model_costs.keys())
     in_current_not_in_desired = current_model_cost_keys - desired_model_costs_keys
     if len(in_current_not_in_desired) > 0:
-        click.echo(f"WARNING: Info for {in_current_not_in_desired} is available but not from the specified cost map!")
+        click.echo(
+            f"WARNING: Info for {in_current_not_in_desired} is available but not from the specified cost map!"
+        )
 
     register_model(model_cost=desired_model_costs)
 

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import json
+import hashlib
 import os
 import re
 import subprocess
@@ -11,6 +12,8 @@ from io import BytesIO
 
 import click
 import datasets
+import httpx
+from litellm import model_cost as litellm_model_cost, register_model
 
 from agenteval.leaderboard.schema_generator import load_dataset_features
 
@@ -130,11 +133,39 @@ def verify_git_reproducibility() -> None:
         )
 
 
-def check_using_local_litellm_model_cost_map():
+def prep_litellm_cost_map():
     if os.getenv("LITELLM_LOCAL_MODEL_COST_MAP") != "True":
         raise click.ClickException(
             f'Please set the LITELLM_LOCAL_MODEL_COST_MAP env variable to "True" before scoring.'
         )
+
+    current_model_cost_keys = set(litellm_model_cost.keys())
+
+    # Can't you just point register_model() at a URL?
+    # Yes, but it won't actually use the url if LITELLM_LOCAL_MODEL_COST_MAP
+    # is set, and that should be set (so we can avoid pulling costs on the fly).
+    # So we'll load the cost file we want ourselves from the URL, and pass its info in as a dict.
+    # This snippet is mostly lifted from
+    # https://github.com/BerriAI/litellm/blob/b9621c760d3355e06dd17ec89b9eb6776755392e/litellm/litellm_core_utils/get_model_cost_map.py#L16
+    response = httpx.get(
+        "https://raw.githubusercontent.com/BerriAI/litellm/eb66daeef740947c0326826817cf68fb56a8b931/litellm/model_prices_and_context_window_backup.json", timeout=5
+    )
+    response.raise_for_status()
+    desired_model_costs = response.json()
+
+    # try to check that we aren't getting info that's not also in or overridden by
+    # the cost file we're pointing at
+    desired_model_costs_keys = set(desired_model_costs.keys())
+    in_current_not_in_desired = current_model_cost_keys - desired_model_costs_keys
+    if len(in_current_not_in_desired) > 0:
+        raise click.ClickException(f"Info for {in_current_not_in_desired} is available but not from the specified cost map!")
+
+    register_model(model_cost=desired_model_costs)
+
+    h = hashlib.sha256()
+    h.update(json.dumps(litellm_model_cost, sort_keys=True).encode())
+    model_cost_hash = h.hexdigest()
+    click.echo(f"Model costs hash {model_cost_hash}.")
 
 
 @click.group()
@@ -155,7 +186,7 @@ def score_command(
 ):
     # so that we know what model costs we're using to score
     # more details in https://github.com/allenai/astabench-issues/issues/391
-    check_using_local_litellm_model_cost_map()
+    prep_litellm_cost_map()
 
     hf_url_match = re.match(HF_URL_PATTERN, log_dir)
     temp_dir: tempfile.TemporaryDirectory | None = None

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import hashlib
+import importlib.metadata
 import json
 import os
 import re
@@ -169,8 +170,15 @@ def prep_litellm_cost_map():
     h = hashlib.sha256()
     h.update(json.dumps(litellm_model_cost, sort_keys=True).encode())
     model_cost_hash = h.hexdigest()
-    click.echo(f"litellm version: {litellm.__version__}")
+    # This is mostly informational... I think it's the case that having
+    # a different hash here doesn't necessarily mean computed cost info
+    # is incompatible.
     click.echo(f"Model costs hash {model_cost_hash}.")
+
+    # Between this and the version of the file we pass to register_model()
+    # I think we can reconstruct the model costs used.
+    litellm_version = importlib.metadata.version("litellm")
+    click.echo(f"litellm version: {litellm_version}")
 
 
 @click.group()


### PR DESCRIPTION
Related to https://github.com/allenai/astabench-issues/issues/391.

We started with https://github.com/allenai/agent-eval/pull/63, but that won't work because it results in dependencies that aren't satisfiable in asta-bench. I think this fixes it though.

The idea builds on what was introduced in https://github.com/allenai/agent-eval/pull/63. We want to avoid automatically pulling new cost info in on the fly, so the code still expects `LITELLM_LOCAL_MODEL_COST_MAP` to be set to true. This means that we'll look at the local cost file. 

The local cost file can change depending on the version of litellm we have. https://github.com/allenai/agent-eval/pull/63 pinned the version of litellm so that we would always be using the same version of the local cost file. But we can't do that because of asta-bench's requirements (specifically, one of the dependencies wants a lower version of litellm). This PR tries to address that by doing two things:
- use `register_model()` with a specific version of the local cost file (the version in litellm's version 1.75.8) - this means litellm will sort of [merge](https://github.com/BerriAI/litellm/blob/b9621c760d3355e06dd17ec89b9eb6776755392e/litellm/utils.py#L2279) the local cost file with the 1.75.8 version of the local cost file, with the 1.75.8 version info getting used when there's conflicts. The idea here is to get information up to 1.75.8's version (the merging process is a little more complicated though, see the litellm.model_cost diff info further down). 
    - This does assume that situations like the following won't happen: there's a model we'd want to score that only has cost info in a local cost file corresponding to older versions of litellm.
- loosen the requirement on litellm version to `litellm<=1.75.8`- this should allow for satisfiable dependencies for asta-bench, and also prevent us from pulling in cost info for models not represented in 1.75.8's local cost file.

Testing done:
I tried scoring `hf://allenai/asta-bench-internal-submissions/1.0.0-dev1/test/miked-ai_ReAct-GPT-5-mini_2025-08-11T16-35-18` with litellm versions 1.75.8 and 1.75.0 (1.75.0 is I think before costs were introduced for gpt 5, which that submission uses. Testing in https://github.com/allenai/agent-eval/pull/63 established that using just the local cost file from 1.75.0 results in null cost results.)

With litellm version 1.75.8:
```
Model costs hash 440711902e484e4eec0b5c3409d3b953fb2164338d84269ac4ecf54694b30aeb.
litellm version: 1.75.8
```

summary stats:

<details>

```
  "stats": {
    "overall": {
      "score": 0.3148783028247495,
      "score_stderr": null,
      "cost": 0.03517972139633324,
      "cost_stderr": null
    },
    "tag/lit": {
      "score": 0.359073892718989,
      "score_stderr": null,
      "cost": 0.0432097658085206,
      "cost_stderr": null
    },
    "tag/data": {
      "score": 0.2692091729748633,
      "score_stderr": null,
      "cost": 0.011127473221757321,
      "cost_stderr": null
    },
    "tag/code": {
      "score": 0.5052960102960103,
      "score_stderr": null,
      "cost": 0.05169765155505505,
      "cost_stderr": null
    },
    "tag/discovery": {
      "score": 0.12593413530913533,
      "score_stderr": null,
      "cost": 0.034683994999999995,
      "cost_stderr": null
    },
    "task/paper_finder_test": {
      "score": 0.1680882137565247,
      "score_stderr": 0.01736167991412297,
      "cost": 0.0384160127340824,
      "cost_stderr": 0.004496229162562603
    },
    "task/paper_finder_litqa2_test": {
      "score": 0.6133333333333333,
      "score_stderr": 0.05661099544085763,
      "cost": 0.11436817,
      "cost_stderr": 0.017359728699967197
    },
    "task/sqa_test": {
      "score": 0.2672615497644688,
      "score_stderr": 0.03773623587370571,
      "cost": 0.0270534035,
      "cost_stderr": 0.0019422575674411598
    },
    "task/arxivdigestables_test": {
      "score": 0.3209458073549626,
      "score_stderr": 0.016795287448771803,
      "cost": 0.012757592,
      "cost_stderr": 0.000598238094979927
    },
    "task/litqa2_test": {
      "score": 0.7466666666666667,
      "score_stderr": 0.05055844297598726,
      "cost": 0.07485594,
      "cost_stderr": 0.014531272631798089
    },
    "task/discoverybench_test": {
      "score": 0.2692091729748633,
      "score_stderr": 0.024402794451474107,
      "cost": 0.011127473221757321,
      "cost_stderr": 0.0006222390294466313
    },
    "task/core_bench_test": {
      "score": 0.4594594594594595,
      "score_stderr": 0.08305895907471071,
      "cost": 0.04720825405405405,
      "cost_stderr": 0.007319669323511871
    },
    "task/ds1000_test": {
      "score": 0.71,
      "score_stderr": 0.015133811749341808,
      "cost": 0.002989897277777778,
      "cost_stderr": 0.0000549948574693956
    },
    "task/e2e_discovery_test": {
      "score": 0.09482323232323234,
      "score_stderr": 0.03868709687867958,
      "cost": 0.02972574375,
      "cost_stderr": 0.0029628950153995407
    },
    "task/e2e_discovery_hard_test": {
      "score": 0.1570450382950383,
      "score_stderr": 0.04217558424596078,
      "cost": 0.03964224625,
      "cost_stderr": 0.004099116765299048
    },
    "task/super_test": {
      "score": 0.3464285714285715,
      "score_stderr": 0.0673848147211148,
      "cost": 0.10489480333333333,
      "cost_stderr": 0.023534508573437658
    }
  }
}
```

</details>

With litellm version 1.75.0:
```
Model costs hash 58077933fa776c069575d1dae827ad3f8422739cf26c7f65d97be342e82a06d4.
litellm version: 1.75.0
```

Summary stats:

<details>

```
    "overall": {
      "score": 0.3148783028247495,
      "score_stderr": null,
      "cost": 0.03517972139633324,
      "cost_stderr": null
    },
    "tag/lit": {
      "score": 0.359073892718989,
      "score_stderr": null,
      "cost": 0.0432097658085206,
      "cost_stderr": null
    },
    "tag/data": {
      "score": 0.2692091729748633,
      "score_stderr": null,
      "cost": 0.011127473221757321,
      "cost_stderr": null
    },
    "tag/code": {
      "score": 0.5052960102960103,
      "score_stderr": null,
      "cost": 0.05169765155505505,
      "cost_stderr": null
    },
    "tag/discovery": {
      "score": 0.12593413530913533,
      "score_stderr": null,
      "cost": 0.034683994999999995,
      "cost_stderr": null
    },
    "task/paper_finder_test": {
      "score": 0.1680882137565247,
      "score_stderr": 0.01736167991412297,
      "cost": 0.0384160127340824,
      "cost_stderr": 0.004496229162562603
    },
    "task/paper_finder_litqa2_test": {
      "score": 0.6133333333333333,
      "score_stderr": 0.05661099544085763,
      "cost": 0.11436817,
      "cost_stderr": 0.017359728699967197
    },
    "task/sqa_test": {
      "score": 0.2672615497644688,
      "score_stderr": 0.03773623587370571,
      "cost": 0.0270534035,
      "cost_stderr": 0.0019422575674411598
    },
    "task/arxivdigestables_test": {
      "score": 0.3209458073549626,
      "score_stderr": 0.016795287448771803,
      "cost": 0.012757592,
      "cost_stderr": 0.000598238094979927
    },
    "task/litqa2_test": {
      "score": 0.7466666666666667,
      "score_stderr": 0.05055844297598726,
      "cost": 0.07485594,
      "cost_stderr": 0.014531272631798089
    },
    "task/discoverybench_test": {
      "score": 0.2692091729748633,
      "score_stderr": 0.024402794451474107,
      "cost": 0.011127473221757321,
      "cost_stderr": 0.0006222390294466313
    },
    "task/core_bench_test": {
      "score": 0.4594594594594595,
      "score_stderr": 0.08305895907471071,
      "cost": 0.04720825405405405,
      "cost_stderr": 0.007319669323511871
    },
    "task/ds1000_test": {
      "score": 0.71,
      "score_stderr": 0.015133811749341808,
      "cost": 0.002989897277777778,
      "cost_stderr": 0.0000549948574693956
    },
    "task/e2e_discovery_test": {
      "score": 0.09482323232323234,
      "score_stderr": 0.03868709687867958,
      "cost": 0.02972574375,
      "cost_stderr": 0.0029628950153995407
    },
    "task/e2e_discovery_hard_test": {
      "score": 0.1570450382950383,
      "score_stderr": 0.04217558424596078,
      "cost": 0.03964224625,
      "cost_stderr": 0.004099116765299048
    },
    "task/super_test": {
      "score": 0.3464285714285715,
      "score_stderr": 0.0673848147211148,
      "cost": 0.10489480333333333,
      "cost_stderr": 0.023534508573437658
    }
  }
}
```

</details>

I also tried looking at litellm.model_cost in both cases... It's not the same. 
- Some of the difference is explicitly listing fields for which the values are None. My best guess for when this happens looking at the register_model() code is when both the local cost file and the cost file we're pointing at have an entry for the same key. Then we start with the dict version of Modelnfo representing the local cost file entry (which I think is where the fields with null values get introduced), and update it with anything in the entry from the cost file we're pointing at. I think this is probably fine.
- supported_openai_params are sometimes listed. Here too, my best guess for when this happens is when both the local cost file and the cost file we're pointing to have the same key. I don't see supported_openai_params in either local cost file, but I think it gets dumped when we start with the dict version of ModelInfo representing the local cost file entry when we have entries from both places for the same key. Probably okay too assuming these don't really change?
- Some entries get a new 'key' field. I think this is a similar situation to the other two - this field exists in ModelInfo and so gets pulled in when entries from both places have the same key. But it's not explicitly listed in the local cost files.
- for `"vertex_ai/claude-opus-4"`, we drop `input_cost_per_token_batches` and `output_cost_per_token_batches`. In the merged model costs for 1.75.0, these have values `input_cost_per_token_batches=7.5e-06` and `output_cost_per_token_batches=3.75e-05`. They have null values in the merged model costs for 1.75.8. They don't appear at all in the local files for either 1.75.0 or 1.75.8. Not sure what's going on there...
- `vertex_ai/claude-opus-4-1` has an entry in the merged costs for 1.75.8 but not in the merged costs for 1.75.0. A little context... When two model cost dicts get merged, it seems like the dict key isn't always what determines the key by which we figure out which entries to merge, see [this](https://github.com/BerriAI/litellm/blob/b9621c760d3355e06dd17ec89b9eb6776755392e/litellm/utils.py#L2306)... The local file for 1.75.0 has nothing for `vertex_ai/claude-opus-4-1`, and the local file for 1.75.8 has `vertex_ai/claude-opus-4-1` and `vertex_ai/claude-opus-4-1@20250805`. I _think_ what maybe happened here is that in 1.75.0, both the `vertex_ai/claude-opus-4-1` and `vertex_ai/claude-opus-4-1@20250805` got mapped to the same key, and the second one won out.

So basically... I think this is imperfect but I'm not sure we can do much better given that going through the merging process seems unavoidable unless you either allow for using the remote file, or pin litellm and don't allow for using the remote file (both of which don't work for us currently). So I think maybe the best we can do rn is something like this and also print out the litellm version the code is on. Between that and the agent-eval commit, we'll have the litellm version and the cost file we're pointing at for register_model, which I _think_ should be enough to reconstruct the cost file used (though not necessarily enough to automatically tell us whether two results with different values here are still comparable cost wise). Ideally we'd save the litellm version somewhere alongside the scores, but maybe we can deal with that in the next iteration...