### PR TITLE
Cost freezing take 3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
   "inspect-ai>=0.3.104",
   # pin litellm so that we know what model costs we're using
   # see the Development.md doc before changing
-  "litellm==1.67.4.post1",
+  "litellm>=1.67.4.post1,<=1.75.8",
   "pydantic>=2.0.0",
   # For leaderboard
   "huggingface_hub",


### PR DESCRIPTION
Related to https://github.com/allenai/astabench-issues/issues/391. Builds on https://github.com/allenai/agent-eval/pull/63, https://github.com/allenai/agent-eval/pull/66.

> Pinning to 1.67.4.post1 seems to work.

I was wrong about this (I thought I'd tested with [this commit](https://github.com/allenai/asta-bench/pull/107/commits/6080396e3ab8081a898ea7b33fc809dfac3f0099), but looks like CI_tests didn't run for that, and I missed it).

CI_test does seem to pass for [this](https://github.com/allenai/asta-bench/pull/107/commits/da0d1734a55872314eb51eaa7d691abb1bc38019), which is the range in this PR too.

Why does this work when pinning doesn't?

So I think there are two different, incompatible, litellm requirements, but they are not in the core requirements of asta-bench.  sqa wants `1.68.0` like @mdarcy220  remembered, and futurehouse wants `1.67.4.post1`. AFAICT we build separate images off an image that has the core requirements for sqa and futurehouse (so we want to be able to build either, but we aren't trying to install both sets of requirements at the same time). So I think that's why the range works and the pinning doesn't... So this PR shifts to @jbragg 's preference of using a range.
