### PR TITLE
LLM names take into account reasoning effort in model args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.41"
+version = "0.1.42"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/leaderboard/model_name_mapping.py
+++ b/src/agenteval/leaderboard/model_name_mapping.py
@@ -85,4 +85,5 @@ LB_MODEL_NAME_MAPPING = {
     "gemini/gemini-2.5-pro": "Gemini 2.5 Pro (unpinned)",
     "openai/gpt-4o": "GPT-4o (unpinned)",
     "gpt-3.5-turbo-0125": "GPT-3.5 Turbo (2025-01)",
+    "openai/gpt-5": "GPT-5 (unpinned)",
 }

--- a/src/agenteval/leaderboard/model_name_mapping.py
+++ b/src/agenteval/leaderboard/model_name_mapping.py
@@ -86,4 +86,5 @@ LB_MODEL_NAME_MAPPING = {
     "openai/gpt-4o": "GPT-4o (unpinned)",
     "gpt-3.5-turbo-0125": "GPT-3.5 Turbo (2025-01)",
     "openai/gpt-5": "GPT-5 (unpinned)",
+    "gpt-5": "GPT-5 (unpinned)",
 }

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -530,7 +530,7 @@ def _get_dataframe(
                     )
                 except ValueError as exc:
                     logger.warning(
-                        f"Dropping submission {sub} because of issues figuring out model details."
+                        f"Dropping submission {sub} because of issues figuring out model details. {exc}"
                     )
                     use_submission = False
 

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -380,7 +380,7 @@ def get_model_name_aliases(raw_name: str) -> set[str]:
 
         # if the pretty name suggests it's unpinned
         # include the pretty version without the date part
-        open_paren_index = pretty_name.index("(")
+        open_paren_index = pretty_name.rindex("(")
         name_date = pretty_name[open_paren_index:].strip()
         if name_date == "(unpinned)":
             dateless_pretty_name = pretty_name[:open_paren_index].strip()

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -513,8 +513,9 @@ def _get_dataframe(
             # e.g. if reasoning effort wasn't at the default for a result
             formatted_names = raw_names_to_formatted_names[raw_name]
             # in case two raw names map to the same formatted name
-            if formatted_name not in model_names:
-                model_names.append(formatted_name)
+            for formatted_name in formatted_names:
+                if formatted_name not in model_names:
+                    model_names.append(formatted_name)
 
         # only format if submit_time present, else leave as None
         ts = sub.submit_time

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -430,14 +430,14 @@ def format_model_names_for_one_result(
                     model_name=map_option,
                     effort=reasoning_effort,
                 )
-                if other_name_option not in model_args_influenced_to_raw:
-                    model_args_influenced_to_raw[other_name_option] = set()
-                model_args_influenced_to_raw[other_name_option].add(raw_name)
+                if other_name_option not in by_model_args_influence_name:
+                    by_model_args_influence_name[other_name_option] = set()
+                by_model_args_influence_name[other_name_option].add(raw_name)
 
         name_to_use = map_option if other_name_option is None else other_name_option
         raw_name_to_formatted_name[raw_name] = name_to_use
 
-    for model_args_influenced, raw_names in model_args_influenced_to_raw.items():
+    for model_args_influenced, raw_names in by_model_args_influence_name.items():
         # Suggests we might have done something wrong in figuring out which
         # model usages are relevant to the model args affecting the model name
         # we want to show.

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -409,6 +409,9 @@ def format_model_names_for_one_result(
         other_name_option = None
 
         if consider_eval_spec:
+            # make mypy happy
+            assert eval_spec is not None
+            assert spec_model_name_aliases is not None
             raw_name_aliases = get_model_name_aliases(raw_name)
             looks_like_same_model = (
                 len(raw_name_aliases.intersection(spec_model_name_aliases)) > 0

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -503,7 +503,7 @@ def _get_dataframe(
                     task_result.model_usages = None
                     task_result.model_costs = None
 
-                models_in_this_task = set([])
+                models_in_this_task = set()
                 if task_result.model_usages:
                     for usage_list in task_result.model_usages:
                         for model_usage in usage_list:

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -385,7 +385,7 @@ def get_model_name_aliases(raw_name: str) -> set[str]:
 def format_model_names_for_one_result(
     raw_names: set[str], eval_spec: EvalSpec
 ) -> set[str]:
-    to_return: set[str] = {}
+    to_return: set[str] = set()
 
     if (eval_spec.model_args is not None) and (
         "reasoning_effort" in eval_spec.model_args
@@ -415,7 +415,7 @@ def format_model_names_for_one_result(
         to_use = safe_name_option if other_name_option is None else other_name_option
         to_return.add(to_use)
 
-    return to_use
+    return to_return
 
 
 def _get_dataframe(
@@ -450,7 +450,7 @@ def _get_dataframe(
 
         model_token_counts: dict[str, int] = {}
         # formatted model names
-        model_names: set[str] = {}
+        model_names: set[str] = set()
 
         if ev.results:
             for task_result in ev.results:

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -381,7 +381,7 @@ def get_model_name_aliases(raw_name: str) -> set[str]:
         open_paren_index = pretty_name.index("(")
         name_date = pretty_name[open_paren_index:].strip()
         if name_date == "(unpinned)":
-            dateless_pretty_name = pretty_name[: open_paren_index].strip()
+            dateless_pretty_name = pretty_name[:open_paren_index].strip()
             aliases.add(dateless_pretty_name)
     return {a.lower() for a in aliases}
 

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -396,6 +396,7 @@ def format_model_names_for_one_result(
     if (
         (eval_spec is not None)
         and (eval_spec.model_args is not None)
+        and (isinstance(eval_spec.model_args), dict)
         and ("reasoning_effort" in eval_spec.model_args)
     ):
         consider_eval_spec = True
@@ -412,6 +413,7 @@ def format_model_names_for_one_result(
             # make mypy happy
             assert eval_spec is not None
             assert spec_model_name_aliases is not None
+            assert isinstance(eval_spec.model_args, dict)
             raw_name_aliases = get_model_name_aliases(raw_name)
             looks_like_same_model = (
                 len(raw_name_aliases.intersection(spec_model_name_aliases)) > 0

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -377,8 +377,12 @@ def get_model_name_aliases(raw_name: str) -> set[str]:
         # pretty just means a value in our LB_MODEL_NAME_MAPPING map
         pretty_name = LB_MODEL_NAME_MAPPING[raw_name]
         aliases.add(pretty_name)
-        # pretty name without the version
-        aliases.add(pretty_name[: pretty_name.index("(")].strip())
+        # pretty name without the date
+        open_paren_index = pretty_name.index("(")
+        name_date = pretty_name[open_paren_index:].strip()
+        if name_date == "(unpinned)":
+            dateless_pretty_name = pretty_name[: open_paren_index].strip()
+            aliases.add(dateless_pretty_name)
     return {a.lower() for a in aliases}
 
 

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -396,7 +396,7 @@ def format_model_names_for_one_result(
     if (
         (eval_spec is not None)
         and (eval_spec.model_args is not None)
-        and (isinstance(eval_spec.model_args), dict)
+        and (isinstance(eval_spec.model_args, dict))
         and ("reasoning_effort" in eval_spec.model_args)
     ):
         consider_eval_spec = True

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -16,9 +16,9 @@ from matplotlib.figure import Figure
 
 from .. import compute_summary_statistics
 from ..config import SuiteConfig
+from ..score import EvalSpec
 from .model_name_mapping import LB_MODEL_NAME_MAPPING
 from .models import LeaderboardSubmission
-from .score import EvalSpec
 
 logger = logging.getLogger(__name__)
 
@@ -379,7 +379,7 @@ def get_model_name_aliases(raw_name: str) -> set[str]:
         aliases.add(pretty_name)
         # pretty name without the version
         aliases.add(pretty_name[: pretty_name.index("(")].strip())
-    return aliases
+    return {a.lower() for a in aliases}
 
 
 def format_model_names_for_one_result(
@@ -391,7 +391,7 @@ def format_model_names_for_one_result(
         "reasoning_effort" in eval_spec.model_args
     ):
         consider_eval_spec = True
-        spec_model_name_aliases = get_model_name_aliases(eval_spec.model_name)
+        spec_model_name_aliases = get_model_name_aliases(eval_spec.model)
     else:
         consider_eval_spec = False
         spec_model_name_aliases = None
@@ -402,7 +402,10 @@ def format_model_names_for_one_result(
 
         if consider_eval_spec:
             raw_name_aliases = get_model_name_aliases(raw_name)
-            if len(spec_model_name_aliases.intersection(raw_name_aliases)):
+            looks_like_same_model = (
+                len(raw_name_aliases.intersection(spec_model_name_aliases)) > 0
+            )
+            if looks_like_same_model:
                 reasoning_effort = eval_spec.model_args["reasoning_effort"]
                 other_name_option = adjust_model_name_for_reasoning_effort(
                     model_name=safe_name_option,

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -389,12 +389,14 @@ def get_model_name_aliases(raw_name: str) -> set[str]:
 
 
 def format_model_names_for_one_result(
-    raw_names: set[str], eval_spec: EvalSpec
+    raw_names: set[str], eval_spec: EvalSpec | None
 ) -> set[str]:
     to_return: set[str] = set()
 
-    if (eval_spec.model_args is not None) and (
-        "reasoning_effort" in eval_spec.model_args
+    if (
+        (eval_spec is not None)
+        and (eval_spec.model_args is not None)
+        and ("reasoning_effort" in eval_spec.model_args)
     ):
         consider_eval_spec = True
         spec_model_name_aliases = get_model_name_aliases(eval_spec.model)

--- a/src/agenteval/leaderboard/view.py
+++ b/src/agenteval/leaderboard/view.py
@@ -377,7 +377,9 @@ def get_model_name_aliases(raw_name: str) -> set[str]:
         # pretty just means a value in our LB_MODEL_NAME_MAPPING map
         pretty_name = LB_MODEL_NAME_MAPPING[raw_name]
         aliases.add(pretty_name)
-        # pretty name without the date
+
+        # if the pretty name suggests it's unpinned
+        # include the pretty version without the date part
         open_paren_index = pretty_name.index("(")
         name_date = pretty_name[open_paren_index:].strip()
         if name_date == "(unpinned)":


### PR DESCRIPTION
Related to https://github.com/allenai/astabench-issues/issues/199, and more generally supports reflecting non-default reasoning effort settings for models as long as those are reflected in EvalSpec's model_args.

The idea is that when this code is processing model usages, including to construct more formatted names for the models, it also looks at any relevant model args. For a given result, if its model args include reasoning effort, it'll attempt to figure out which model names from model usages that corresponds to, and add in the effort to the formatted model name.

Note: at first I had a more complicated version of this, which would only include the effort if it seemed like the same model didn't end up getting mapped to a name without the effort once all the results in the submission had been processed... But then it occurred to me that since model_args is on the result level, if in theory an effort setting were to exist in the model args for one result but not in the model args for another result in the same submission, it would make sense to end up with both versions of the model name. But let me know if you think that version would be better...

Testing done:

This branch

For the results of interest `pclark425_Asta_DataVoyager_2025-08-14T21-31-12`, with reasoning effort in the model args:
```
['gpt-5', 'openai/gpt-4o'] -> ['gpt-5 (reasoning_effort=minimal)', 'GPT-4o (unpinned)']
```

Same result, without reasoning effort in the model args:
```
['gpt-5', 'openai/gpt-4o'] -> ['gpt-5', 'GPT-4o (unpinned)']
```


For a couple of other results:
`aps6992_FutureHouse_FALCON_2025-07-26T17-31-12`
```
['openai/gpt-4.1-mini', 'models/gemini-2.5-flash-preview-05-20', 'openai/o3-mini'] -> ['GPT-4.1 Mini (unpinned)', 'Gemini 2.5 Flash (2024-05)', 'o3 Mini (unpinned)']
```

`aps6992_Asta_Scholar_QA__No_Tables__2025-07-23T22-38-03`
```
['anthropic/claude-sonnet-4-20250514'] -> ['Claude Sonnet 4 (2025-05)']
```

vs main

For the results of interest `pclark425_Asta_DataVoyager_2025-08-14T21-31-12`, with reasoning effort in the model args:
```
['gpt-5', 'openai/gpt-4o'] -> ['gpt-5', 'GPT-4o (unpinned)']
```


Same result, without reasoning effort in the model args:
```
['gpt-5', 'openai/gpt-4o'] -> ['gpt-5', 'GPT-4o (unpinned)']
```

For `aps6992_FutureHouse_FALCON_2025-07-26T17-31-12`:
```
['openai/gpt-4.1-mini', 'models/gemini-2.5-flash-preview-05-20', 'openai/o3-mini'] -> ['GPT-4.1 Mini (unpinned)', 'Gemini 2.5 Flash (2024-05)', 'o3 Mini (unpinned)']
```

For `aps6992_Asta_Scholar_QA__No_Tables__2025-07-23T22-38-03`:
```
['anthropic/claude-sonnet-4-20250514'] -> ['Claude Sonnet 4 (2025-05)']
```