### PR TITLE
handle moonshot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.45"
+version = "0.1.46"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/local_cost.py
+++ b/src/agenteval/local_cost.py
@@ -1,6 +1,5 @@
-from typing import TypedDict
-
 from litellm.utils import CostPerToken
+from pydantic import BaseModel
 
 # even where these exist in https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
 # calling cost_per_token does not return a cost, perhaps due to the associated provider
@@ -37,7 +36,7 @@ CUSTOM_PRICING = {
 }
 
 
-class CostPerTokenWithCache(TypedDict):
+class CostPerTokenWithCache(BaseModel):
     input_cost_per_token: float
     output_cost_per_token: float
     cache_read_input_token_cost: float

--- a/src/agenteval/local_cost.py
+++ b/src/agenteval/local_cost.py
@@ -1,3 +1,5 @@
+from typing import TypedDict
+
 from litellm.utils import CostPerToken
 
 # even where these exist in https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json
@@ -31,5 +33,25 @@ CUSTOM_PRICING = {
     ),
     "akariasai/os_8b": CostPerToken(
         input_cost_per_token=1.8e-07, output_cost_per_token=1.8e-07
+    ),
+}
+
+
+class CostPerTokenWithCache(TypedDict):
+    input_cost_per_token: float
+    output_cost_per_token: float
+    cache_read_input_token_cost: float
+
+
+# Like CUSTOM_PRICING, but for models that also have a cache read discount.
+# cost_per_token with usage_object doesn't work for these models in litellm 1.75.8,
+# so costs are computed manually in compute_model_cost.
+# key represents model name as found in inspect model_usage
+CUSTOM_PRICING_WITH_CACHE = {
+    # costs from https://platform.moonshot.ai/docs/guide/kimi-k2-5-quickstart
+    "moonshotai/kimi-k2.5-0127": CostPerTokenWithCache(
+        input_cost_per_token=6e-07,
+        output_cost_per_token=3e-06,
+        cache_read_input_token_cost=1e-07,
     ),
 }

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -15,7 +15,7 @@ from litellm import cost_per_token
 from litellm.types.utils import PromptTokensDetailsWrapper, Usage
 from pydantic import BaseModel
 
-from .local_cost import CUSTOM_PRICING
+from .local_cost import CUSTOM_PRICING, CUSTOM_PRICING_WITH_CACHE
 
 logger = getLogger(__name__)
 
@@ -112,6 +112,17 @@ def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float | None:
                     completion_tokens=output_tokens,
                     custom_cost_per_token=CUSTOM_PRICING[model_usage.model],
                 )
+
+            elif model_usage.model in CUSTOM_PRICING_WITH_CACHE.keys():
+
+                pricing = CUSTOM_PRICING_WITH_CACHE[model_usage.model]
+                cache_read_tokens = model_usage.usage.input_tokens_cache_read or 0
+                text_tokens = input_tokens - cache_read_tokens
+                prompt_cost = (
+                    text_tokens * pricing["input_cost_per_token"]
+                    + cache_read_tokens * pricing["cache_read_input_token_cost"]
+                )
+                completion_cost = output_tokens * pricing["output_cost_per_token"]
 
             else:
                 total_tokens = model_usage.usage.total_tokens

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -119,10 +119,10 @@ def compute_model_cost(model_usages: list[ModelUsageWithName]) -> float | None:
                 cache_read_tokens = model_usage.usage.input_tokens_cache_read or 0
                 text_tokens = input_tokens - cache_read_tokens
                 prompt_cost = (
-                    text_tokens * pricing["input_cost_per_token"]
-                    + cache_read_tokens * pricing["cache_read_input_token_cost"]
+                    text_tokens * pricing.input_cost_per_token
+                    + cache_read_tokens * pricing.cache_read_input_token_cost
                 )
-                completion_cost = output_tokens * pricing["output_cost_per_token"]
+                completion_cost = output_tokens * pricing.output_cost_per_token
 
             else:
                 total_tokens = model_usage.usage.total_tokens


### PR DESCRIPTION
I am attempting to score an external submission for AstaBench:
https://huggingface.co/datasets/allenai/asta-bench-submissions/tree/main/1.0.0/test/EvoScientist_EvoScientist_Coder_2026-03-19_16-22-34

The solver args show this provider `openrouter/moonshotai/kimi-k2.5`, which comes through in the inspect model usage objects like this:

```
{
model: "moonshotai/kimi-k2.5-0127",
usage: {
input_tokens: 7467,
output_tokens: 829,
total_tokens: 8296,
input_tokens_cache_write: null,
input_tokens_cache_read: 6144,
reasoning_tokens: 284
}
```

Moonshot is supported as an inference provider in litellm and some cost objects have been added to https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json

However, these are not available in the version of litellm which we have chosen to pin, 1.75.8 (and in fact may not yet be in a released version). This PR adds pricing in local_cost to handle this provider/model.
