### PR TITLE
Fix sync-schema bug; add dirty and total_cost schema fields for inspect_ai compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,8 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "click",
-  # Pin inspect-ai to avoid breaking changes in 0.3.137+ (Event classes moved)
-  # See allenai/astabench-issues#275 for upgrade process
-  "inspect-ai>=0.3.104,<0.3.137",
+  # Pin to tested version; see allenai/nora-issues#2733 for upgrade history
+  "inspect-ai==0.3.203",
   # pin litellm so that we know what model costs we're using
   # see the Development.md doc before changing
   "litellm>=1.67.4.post1,<=1.82.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.46"
+version = "0.1.47"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -34,6 +34,7 @@ def sync_schema(repo_id: str, dry_run: bool):
         click.echo(f"Would update hf://{repo_id}/README.md to:")
         print(str(readme))
     else:
+        readme.features = local_features
         readme.upload(repo_id=repo_id, comment="Update results schema")
         click.echo(f"Updated hf://{repo_id}/README.md")
 

--- a/src/agenteval/leaderboard/dataset_features.yml
+++ b/src/agenteval/leaderboard/dataset_features.yml
@@ -52,6 +52,8 @@
         dtype: string
       - name: commit
         dtype: string
+      - name: dirty
+        dtype: bool
     - name: packages
       dtype: string
   - name: metrics
@@ -79,6 +81,8 @@
           dtype: int64
         - name: reasoning_tokens
           dtype: int64
+        - name: total_cost
+          dtype: float64
   - name: model_costs
     list: float64
 - name: submission

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -2,7 +2,7 @@
 
 from logging import getLogger
 
-from inspect_ai.log import (
+from inspect_ai.log._transcript import (
     Event,
     ModelEvent,
     ScoreEvent,

--- a/src/agenteval/log.py
+++ b/src/agenteval/log.py
@@ -2,7 +2,7 @@
 
 from logging import getLogger
 
-from inspect_ai.log._transcript import (
+from inspect_ai.log import (  # type: ignore[attr-defined]
     Event,
     ModelEvent,
     ScoreEvent,

--- a/tests/test_collect_model_usage.py
+++ b/tests/test_collect_model_usage.py
@@ -6,7 +6,12 @@ from random import Random
 import inspect_ai
 from inspect_ai import Task, task
 from inspect_ai.dataset import MemoryDataset, Sample
-from inspect_ai.log import ModelEvent, ScoreEvent, SpanBeginEvent, SpanEndEvent  # type: ignore[attr-defined]
+from inspect_ai.log import (  # type: ignore[attr-defined]
+    ModelEvent,
+    ScoreEvent,
+    SpanBeginEvent,
+    SpanEndEvent,
+)
 from inspect_ai.model import (
     ChatMessageSystem,
     GenerateConfig,

--- a/tests/test_collect_model_usage.py
+++ b/tests/test_collect_model_usage.py
@@ -6,7 +6,7 @@ from random import Random
 import inspect_ai
 from inspect_ai import Task, task
 from inspect_ai.dataset import MemoryDataset, Sample
-from inspect_ai.log import ModelEvent, ScoreEvent, SpanBeginEvent, SpanEndEvent
+from inspect_ai.log._transcript import ModelEvent, ScoreEvent, SpanBeginEvent, SpanEndEvent
 from inspect_ai.model import (
     ChatMessageSystem,
     GenerateConfig,

--- a/tests/test_collect_model_usage.py
+++ b/tests/test_collect_model_usage.py
@@ -6,7 +6,7 @@ from random import Random
 import inspect_ai
 from inspect_ai import Task, task
 from inspect_ai.dataset import MemoryDataset, Sample
-from inspect_ai.log._transcript import ModelEvent, ScoreEvent, SpanBeginEvent, SpanEndEvent
+from inspect_ai.log import ModelEvent, ScoreEvent, SpanBeginEvent, SpanEndEvent  # type: ignore[attr-defined]
 from inspect_ai.model import (
     ChatMessageSystem,
     GenerateConfig,


### PR DESCRIPTION
part of the path to https://github.com/allenai/nora-issues/issues/2720

## Summary

- **Fix `sync-schema` bug**: `update_readme.py sync-schema` was uploading the downloaded HF README unchanged instead of applying the local `dataset_features.yml`. Added missing `readme.features = local_features` before upload. The script has never actually worked until now.
- **Add `dirty: bool` to `revision` struct**: field added by inspect_ai >= 0.3.137 to `EvalRevision`
- **Add `total_cost: float64` to `usage` struct**: field added by inspect_ai >= 0.3.183 to `ModelUsage`
- **Pin inspect-ai to 0.3.203**: previous pin (`<0.3.137`) prevented reading logs produced by newer inspect versions. 0.3.203 is ~the minimum~ a known version that correctly plumbs reasoning parameters for all models in our current eval suite (GPT-5.4, Gemini 3, Claude Opus/Sonnet 4.6) - even 0.3.202 had several issues respective to these runs. See allenai/nora-issues#2720 and allenai/nora-issues#2733 for full context.

## Test plan

- [x] Run `python scripts/update_readme.py sync-schema --dry-run --repo-id allenai/asta-bench-internal-results` and verify output shows the updated schema
- [x] Run without `--dry-run` and verify a commit appears on the HF repo
- [x] Run `astabench lb view` against a result produced with inspect_ai >= 0.3.183 and confirm no `DatasetGenerationError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)