### PR TITLE
Let child exit gracefully on Ctrl-C to `astabench eval`

### DIFF
--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -1084,9 +1084,35 @@ def eval_command(
         return
 
     click.echo(f"Running {' '.join(inspect_command)}")
-    proc = subprocess.run(inspect_command)
+    # Popen + our own Ctrl-C handling; `subprocess.run` would automatically
+    # SIGKILL the child and skip cleanup
+    proc = subprocess.Popen(inspect_command)
+    try:
+        returncode = proc.wait()
+    except KeyboardInterrupt:
+        click.echo(
+            f"\nInterrupt received; waiting for inspect (pid {proc.pid}) to "
+            f"finish sandbox cleanup.\n"
+            f"  - If Ctrl-C went to the whole process group (the usual case "
+            f"when running `astabench eval` directly in a terminal), inspect "
+            f"already received SIGINT and is cleaning up -- just wait.\n"
+            f"  - If only this process was signalled (e.g. a wrapper script "
+            f"forwarded SIGINT by PID rather than to the process group), "
+            f"inspect did NOT receive SIGINT and will not exit on its own; "
+            f"in another terminal run `kill -INT {proc.pid}` to trigger its "
+            f"cleanup.\n"
+            f"  - Press Ctrl-C again to give up and SIGKILL inspect (may "
+            f"leave orphan sandbox containers).",
+            err=True,
+        )
+        try:
+            returncode = proc.wait()
+        except KeyboardInterrupt:
+            click.echo("Aborting: sending SIGKILL to inspect.", err=True)
+            proc.kill()
+            returncode = proc.wait()
 
-    if proc.returncode != 0:
+    if returncode != 0:
         raise click.ClickException(
             f"inspect eval-set failed while running {config_path}"
         )

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -4,6 +4,7 @@ import importlib.metadata
 import json
 import os
 import re
+import signal
 import subprocess
 import sys
 import tempfile
@@ -1087,9 +1088,11 @@ def eval_command(
     # Popen + our own Ctrl-C handling; `subprocess.run` would automatically
     # SIGKILL the child and skip cleanup
     proc = subprocess.Popen(inspect_command)
+    interrupted = False
     try:
         returncode = proc.wait()
     except KeyboardInterrupt:
+        interrupted = True
         click.echo(
             f"\nInterrupt received; waiting for inspect (pid {proc.pid}) to "
             f"finish sandbox cleanup.\n"
@@ -1111,6 +1114,9 @@ def eval_command(
             click.echo("Aborting: sending SIGKILL to inspect.", err=True)
             proc.kill()
             returncode = proc.wait()
+
+    if interrupted and returncode in (-signal.SIGINT, 128 + signal.SIGINT):
+        raise click.Abort()
 
     if returncode != 0:
         raise click.ClickException(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,11 @@
 import os
+import signal
 import tempfile
 
+import pytest
 from click.testing import CliRunner
 
+import agenteval.cli as cli_module
 from agenteval.cli import cli
 
 
@@ -269,3 +272,85 @@ splits:
 
             assert result.exit_code != 0
             assert "No tasks match the specified filters" in result.output
+
+    @pytest.mark.parametrize("returncode", [-signal.SIGINT, 128 + signal.SIGINT])
+    def test_eval_interrupt_with_sigint_returncode_aborts(
+        self, monkeypatch, returncode
+    ):
+        """Test Ctrl-C followed by inspect's SIGINT exit is reported as abort."""
+
+        class FakeProc:
+            pid = 12345
+
+            def __init__(self):
+                self.wait_calls = 0
+
+            def wait(self):
+                self.wait_calls += 1
+                if self.wait_calls == 1:
+                    raise KeyboardInterrupt()
+                return returncode
+
+        monkeypatch.setattr(cli_module.subprocess, "Popen", lambda command: FakeProc())
+
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = self._create_test_config(tmpdir)
+            log_dir = os.path.join(tmpdir, "logs")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "eval",
+                    "--config-path",
+                    config_path,
+                    "--split",
+                    "test",
+                    "--ignore-git",
+                    "--log-dir",
+                    log_dir,
+                ],
+            )
+
+        assert result.exit_code != 0
+        assert "Aborted!" in result.output
+        assert "inspect eval-set failed" not in result.output
+
+    def test_eval_interrupt_with_non_sigint_returncode_fails(self, monkeypatch):
+        """Test non-SIGINT inspect failures after Ctrl-C are still reported."""
+
+        class FakeProc:
+            pid = 12345
+
+            def __init__(self):
+                self.wait_calls = 0
+
+            def wait(self):
+                self.wait_calls += 1
+                if self.wait_calls == 1:
+                    raise KeyboardInterrupt()
+                return 1
+
+        monkeypatch.setattr(cli_module.subprocess, "Popen", lambda command: FakeProc())
+
+        runner = CliRunner()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = self._create_test_config(tmpdir)
+            log_dir = os.path.join(tmpdir, "logs")
+
+            result = runner.invoke(
+                cli,
+                [
+                    "eval",
+                    "--config-path",
+                    config_path,
+                    "--split",
+                    "test",
+                    "--ignore-git",
+                    "--log-dir",
+                    log_dir,
+                ],
+            )
+
+        assert result.exit_code != 0
+        assert "inspect eval-set failed" in result.output


### PR DESCRIPTION
This is the fix I was referring to in https://github.com/allenai/agent-baselines/pull/25#discussion_r3228101492