### PR TITLE
Bump litellm pin to <=1.88.1 and sync cost map to v1.88.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.50"
+version = "0.1.51"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -14,7 +14,7 @@ dependencies = [
   "inspect-ai==0.3.203",
   # pin litellm so that we know what model costs we're using
   # see the Development.md doc before changing
-  "litellm>=1.67.4.post1,<=1.83.13",
+  "litellm>=1.67.4.post1,<=1.88.1",
   "pydantic>=2.0.0",
   # For leaderboard
   "huggingface_hub",

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -160,7 +160,9 @@ def prep_litellm_cost_map():
     # This snippet is mostly lifted from
     # https://github.com/BerriAI/litellm/blob/b9621c760d3355e06dd17ec89b9eb6776755392e/litellm/litellm_core_utils/get_model_cost_map.py#L16
     # See the Development.md before changing.
-    desired_model_costs_url = "https://raw.githubusercontent.com/BerriAI/litellm/319193604cfccb1092a17f58ec4ca049115da446/litellm/model_prices_and_context_window_backup.json"
+    # SHA below is the v1.88.1 release tag of BerriAI/litellm (upper bound of the
+    # litellm pin in pyproject.toml); keep the two in sync when bumping.
+    desired_model_costs_url = "https://raw.githubusercontent.com/BerriAI/litellm/9c117a58be8fb8066e833aa92dd98fdf15771e50/litellm/model_prices_and_context_window_backup.json"
     response = httpx.get(desired_model_costs_url, timeout=5)
     response.raise_for_status()
     desired_model_costs = response.json()


### PR DESCRIPTION
## What

- Raise the litellm pin upper bound in `pyproject.toml` from `1.83.13` to `1.88.1`.
- Point `desired_model_costs_url` in `prep_litellm_cost_map()` (`src/agenteval/cli.py`) at `model_prices_and_context_window_backup.json` from the litellm **v1.88.1** release tag (SHA `9c117a58be8fb8066e833aa92dd98fdf15771e50`), replacing the previous `319193…` SHA.
- Bump `agent-eval` version `0.1.50` → `0.1.51`.

## Why

Scoring an asta-bench submission requires the litellm **1.88.1** model cost map, which is above the current `<=1.83.13` ceiling. This follows the "Bumping litellm" guidance in `Development.md`: when bumping the pin, update the cost-map SHA to the version at the upper bound (here, the v1.88.1 tag). The two are now kept explicitly in sync via a code comment.

The cost-map backup JSON at the new SHA was confirmed reachable (HTTP 200).

Requested by @reganh for asta-bench submissions review (see allenai/nora wiki "Asta-Bench-Leaderboard: Submissions Review").

## Follow-ups / notes for reviewer

- Per `Development.md`, bumping the cost map may warrant **rescoring results of interest** with this version. That is a separate, manual step run against the HuggingFace submissions dataset and is not part of this PR.
- CI (black 24.2.0 / flake8 / mypy 1.15) should run on this branch; changes are limited to a version string and two string literals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)