### PR TITLE
Make solve-time contract independent of Inspect

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -7,6 +7,54 @@ on:
     branches: [ main ]
 
 jobs:
+  test-inspect-free-contract:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install base package without scoring dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+
+      - name: Verify solve contract imports without inspect-ai
+        run: |
+          python - <<'PY'
+          import importlib.util
+          import tempfile
+          from pathlib import Path
+
+          import agenteval
+          from agenteval.config import load_suite_config
+          from agenteval.io import atomic_write_file, verify_git_reproducibility
+          from agenteval.models import EvalConfig
+
+          assert importlib.util.find_spec("inspect_ai") is None
+          assert "inspect_ai" not in agenteval.__dict__
+
+          config_yaml = """name: smoke\nversion: 1.0.0\nsplits:\n  - name: test\n    tasks:\n      - name: task\n        path: task.py\n        primary_metric: accuracy\n"""
+          with tempfile.TemporaryDirectory() as tmpdir:
+              config_path = Path(tmpdir) / "suite.yml"
+              atomic_write_file(config_path, config_yaml)
+              suite = load_suite_config(config_path)
+              encoded = EvalConfig(
+                  suite_config=suite,
+                  split="test",
+                  inspect_command=["inspect", "eval-set", "task.py"],
+              ).model_dump_json()
+              decoded = EvalConfig.model_validate_json(encoded)
+              assert decoded.task_names == {"task"}
+
+          assert callable(verify_git_reproducibility)
+          PY
+
   test-core:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -20,9 +20,12 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
+        # The core suite exercises the scoring path (score.py/log.py) and tests/conftest.py
+        # imports inspect_ai, so it needs the scoring extra. inspect-ai is no longer a base
+        # dependency (moved to the scoring extra; see pyproject / allenai/gas2own#346).
         run: |
           python -m pip install --upgrade pip
-          pip install .[dev]
+          pip install .[dev,scoring]
 
       - name: Check Code Style
         run: make code-check

--- a/.github/workflows/ci-validate-schema.yml
+++ b/.github/workflows/ci-validate-schema.yml
@@ -20,7 +20,10 @@ jobs:
           python-version: '3.10'
 
       - name: Install dependencies
-        run: pip install -e .
+        # The leaderboard submission schema embeds inspect-ai types (EvalSpec.revision:
+        # EvalRevision, via TaskResult), so schema generation needs the scoring extra.
+        # inspect-ai is no longer a base dependency (see pyproject / allenai/gas2own#346).
+        run: pip install -e .[scoring]
 
       - name: Check if schema is up to date
         run: python scripts/update_schema.py --check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   # see the Development.md doc before changing
   "litellm>=1.67.4.post1,<=1.88.1",
   "pydantic>=2.0.0",
+  "pyyaml",
   # For leaderboard
   "huggingface_hub",
   "pyarrow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,8 +10,14 @@ readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
   "click",
-  # Pin to tested version; see allenai/nora-issues#2733 for upgrade history
-  "inspect-ai==0.3.203",
+  # NOTE: inspect-ai is deliberately NOT a base dependency. It is only needed by
+  # the scoring path (agenteval.score / .log / .summary / .leaderboard); the
+  # config/EvalConfig/io/repro "contract" that solve environments import is
+  # inspect-free. Keeping inspect out of the base install lets a solver env
+  # (e.g. astabench solve, which needs a newer inspect for inspect-swe) depend on
+  # agent-eval without the ==0.3.203 pin winning uv's re-resolution and
+  # downgrading its runtime. See allenai/gas2own#346. Install the `scoring`
+  # (or `leaderboard`) extra to get inspect for scoring.
   # pin litellm so that we know what model costs we're using
   # see the Development.md doc before changing
   "litellm>=1.67.4.post1,<=1.88.1",
@@ -42,8 +48,15 @@ dev = [
   "pandas-stubs",
   "types-seaborn"
 ]
-# Leaderboard view dependencies
+# Scoring dependencies. inspect-ai is required to read .eval logs and compute
+# scores; it lives here (not in base) so solve-only consumers stay inspect-free.
+# Pin to tested version; see allenai/nora-issues#2733 for upgrade history.
+scoring = [
+  "inspect-ai==0.3.203",
+]
+# Leaderboard view dependencies (scoring + plotting)
 leaderboard = [
+  "agent-eval[scoring]",
   "seaborn",
   "matplotlib",
   "pandas"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-eval"
-version = "0.1.51"
+version = "0.1.52"
 description = "Agent evaluation toolkit"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/agenteval/__init__.py
+++ b/src/agenteval/__init__.py
@@ -1,13 +1,27 @@
+import importlib
 from importlib.metadata import version as get_version
 
 __version__ = get_version("agent-eval")
 
-from .leaderboard.upload import upload_folder_to_hf
-from .score import process_eval_logs
-from .summary import compute_summary_statistics
+# The scoring/leaderboard entrypoints pull in inspect-ai (and other heavy,
+# scoring-only deps). Expose them lazily so that merely importing `agenteval`
+# — or an inspect-free submodule like `agenteval.config` — does not force
+# inspect to be installed. See allenai/gas2own#346.
+_LAZY_ATTRS = {
+    "process_eval_logs": "agenteval.score",
+    "compute_summary_statistics": "agenteval.summary",
+    "upload_folder_to_hf": "agenteval.leaderboard.upload",
+}
 
-__all__ = [
-    "process_eval_logs",
-    "compute_summary_statistics",
-    "upload_folder_to_hf",
-]
+__all__ = ["process_eval_logs", "compute_summary_statistics", "upload_folder_to_hf"]
+
+
+def __getattr__(name: str):
+    module_name = _LAZY_ATTRS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(module_name), name)
+
+
+def __dir__():
+    return sorted(list(globals()) + __all__)

--- a/src/agenteval/cli.py
+++ b/src/agenteval/cli.py
@@ -31,15 +31,15 @@ from .config import (
     TOOL_USAGE_STANDARD,
     load_suite_config,
 )
-from .io import atomic_write_file
+from .io import atomic_write_file, verify_git_reproducibility
 from .leaderboard.models import LeaderboardSubmission, Readme
 from .leaderboard.upload import (
     compress_model_usages,
     sanitize_path_component,
     upload_folder_to_hf,
 )
-from .models import EvalConfig, SubmissionMetadata, TaskResults
-from .score import process_eval_logs
+from .models import EvalConfig, SubmissionMetadata
+from .score import TaskResults, process_eval_logs
 from .summary import compute_summary_statistics
 
 HF_URL_PATTERN = r"^hf://(?:datasets/)?(?P<repo_id>[^/]+/[^/]+)/(?P<path>.*)$"
@@ -70,79 +70,6 @@ def parse_hf_url(url: str) -> tuple[str, str]:
         sys.exit(1)
 
     return hf_url_match.group("repo_id"), hf_url_match.group("path")
-
-
-def verify_git_reproducibility() -> None:
-    try:
-        # Get current commit SHA and origin
-        sha_result = subprocess.run(
-            ["git", "rev-parse", "--short", "HEAD"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        origin_result = subprocess.run(
-            ["git", "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        sha = sha_result.stdout.strip() if sha_result.returncode == 0 else None
-        origin = origin_result.stdout.strip() if origin_result.returncode == 0 else None
-
-        # Check for dirty working directory
-        git_dirty = (
-            subprocess.run(
-                ["git", "diff", "--quiet", "--exit-code"],
-                capture_output=True,
-                check=False,
-            ).returncode
-            != 0
-        )
-
-        # Warn about untracked (non-ignored) files
-        untracked_result = subprocess.run(
-            ["git", "ls-files", "--others", "--exclude-standard"],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-        untracked_files = untracked_result.stdout.strip().splitlines()
-        if untracked_files:
-            click.echo(
-                f"Warning: Untracked files present: {', '.join(untracked_files)}. "
-                "For reproducibility, please add, ignore, or remove these files."
-            )
-
-        # Abort if worktree is dirty
-        if git_dirty:
-            raise click.ClickException(
-                f"Git working directory contains uncommitted changes. "
-                f"For reproducibility, Inspect will save: origin={origin}, sha={sha}. "
-                "Please commit your changes or use --ignore-git to bypass this check (not recommended)."
-            )
-
-        # Check if commit exists on remote
-        if sha:
-            remote_exists = subprocess.run(
-                ["git", "branch", "-r", "--contains", sha],
-                capture_output=True,
-                text=True,
-                check=True,
-            ).stdout.strip()
-            if not remote_exists:
-                raise click.ClickException(
-                    f"Commit {sha} not found on remote '{origin}'. Others won't be able to "
-                    "access this code version. Please push your changes or use --ignore-git "
-                    "to bypass this check (not recommended)."
-                )
-    except (subprocess.SubprocessError, FileNotFoundError) as e:
-        if isinstance(e, click.ClickException):
-            raise
-        raise click.ClickException(
-            f"Unable to verify git status for reproducibility: {e}. "
-            "Use --ignore-git to bypass this check if git is not available."
-        )
 
 
 def prep_litellm_cost_map():

--- a/src/agenteval/io.py
+++ b/src/agenteval/io.py
@@ -1,6 +1,9 @@
 import os
+import subprocess
 import tempfile
 from pathlib import Path
+
+import click
 
 
 def atomic_write_file(
@@ -36,3 +39,76 @@ def atomic_write_file(
             os.remove(tmp.name)
         except FileNotFoundError:
             pass
+
+
+def verify_git_reproducibility() -> None:
+    try:
+        # Get current commit SHA and origin
+        sha_result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        origin_result = subprocess.run(
+            ["git", "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        sha = sha_result.stdout.strip() if sha_result.returncode == 0 else None
+        origin = origin_result.stdout.strip() if origin_result.returncode == 0 else None
+
+        # Check for dirty working directory
+        git_dirty = (
+            subprocess.run(
+                ["git", "diff", "--quiet", "--exit-code"],
+                capture_output=True,
+                check=False,
+            ).returncode
+            != 0
+        )
+
+        # Warn about untracked (non-ignored) files
+        untracked_result = subprocess.run(
+            ["git", "ls-files", "--others", "--exclude-standard"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        untracked_files = untracked_result.stdout.strip().splitlines()
+        if untracked_files:
+            click.echo(
+                f"Warning: Untracked files present: {', '.join(untracked_files)}. "
+                "For reproducibility, please add, ignore, or remove these files."
+            )
+
+        # Abort if worktree is dirty
+        if git_dirty:
+            raise click.ClickException(
+                f"Git working directory contains uncommitted changes. "
+                f"For reproducibility, Inspect will save: origin={origin}, sha={sha}. "
+                "Please commit your changes or use --ignore-git to bypass this check (not recommended)."
+            )
+
+        # Check if commit exists on remote
+        if sha:
+            remote_exists = subprocess.run(
+                ["git", "branch", "-r", "--contains", sha],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.strip()
+            if not remote_exists:
+                raise click.ClickException(
+                    f"Commit {sha} not found on remote '{origin}'. Others won't be able to "
+                    "access this code version. Please push your changes or use --ignore-git "
+                    "to bypass this check (not recommended)."
+                )
+    except (subprocess.SubprocessError, FileNotFoundError) as e:
+        if isinstance(e, click.ClickException):
+            raise
+        raise click.ClickException(
+            f"Unable to verify git status for reproducibility: {e}. "
+            "Use --ignore-git to bypass this check if git is not available."
+        )

--- a/src/agenteval/leaderboard/models.py
+++ b/src/agenteval/leaderboard/models.py
@@ -6,7 +6,9 @@ import yaml
 from datasets import Features
 from pydantic import BaseModel, Field
 
-from ..models import SubmissionMetadata, SuiteConfig, TaskResult
+from ..config import SuiteConfig
+from ..models import SubmissionMetadata
+from ..score import TaskResult
 
 
 class LeaderboardSubmission(BaseModel):

--- a/src/agenteval/models.py
+++ b/src/agenteval/models.py
@@ -4,7 +4,6 @@ from functools import cached_property
 from pydantic import BaseModel
 
 from .config import SuiteConfig
-from .score import TaskResult
 
 
 class EvalConfig(BaseModel):
@@ -41,54 +40,3 @@ class SubmissionMetadata(BaseModel):
     summary_url: str | None = None
     openness: str | None = None
     tool_usage: str | None = None
-
-
-class TaskResults(BaseModel):
-    """Scores for all tasks in the suite"""
-
-    results: list[TaskResult]
-    cost_map_url: str | None = None
-    """URL of the litellm model pricing JSON used to compute costs.
-    Points to a specific git commit so the cost basis is exactly reproducible."""
-
-    @cached_property
-    def agent_specs(self) -> set[str]:
-        specs: set[str] = set()
-        for task_result in self.results or []:
-            if task_result.eval_spec:
-                agent_spec = task_result.eval_spec.model_dump_json(
-                    include={"solver", "solver_args", "model", "model_args"}
-                )
-                specs.add(agent_spec)
-        return specs
-
-    @cached_property
-    def code_specs(self) -> set[str]:
-        specs: set[str] = set()
-        for task_result in self.results or []:
-            if task_result.eval_spec:
-                code_spec = task_result.eval_spec.model_dump_json(
-                    include={"revision", "packages"}
-                )
-                specs.add(code_spec)
-        return specs
-
-    @cached_property
-    def tasks_with_args(self) -> list[str]:
-        tasks_with_args: list[str] = []
-        for task_result in self.results or []:
-            if task_result.eval_spec and task_result.eval_spec.task_args_passed:
-                tasks_with_args.append(task_result.task_name)
-        return tasks_with_args
-
-    @cached_property
-    def task_names(self) -> set[str]:
-        """
-        Get the names of all tasks in the results.
-
-        Returns:
-            List of task names.
-        """
-        return (
-            set(result.task_name for result in self.results) if self.results else set()
-        )

--- a/src/agenteval/models.py
+++ b/src/agenteval/models.py
@@ -1,3 +1,4 @@
+import importlib
 from datetime import datetime
 from functools import cached_property
 
@@ -40,3 +41,23 @@ class SubmissionMetadata(BaseModel):
     summary_url: str | None = None
     openness: str | None = None
     tool_usage: str | None = None
+
+
+# These inspect-bound types historically lived in this module. Keep lazy
+# compatibility aliases so existing scoring consumers continue to work while
+# importing EvalConfig remains inspect-free for solve environments.
+_LAZY_ATTRS = {
+    "TaskResult": "agenteval.score",
+    "TaskResults": "agenteval.score",
+}
+
+
+def __getattr__(name: str):
+    module_name = _LAZY_ATTRS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(module_name), name)
+
+
+def __dir__():
+    return sorted(list(globals()) + list(_LAZY_ATTRS))

--- a/src/agenteval/score.py
+++ b/src/agenteval/score.py
@@ -1,6 +1,7 @@
 """Scoring utilities for the NoraBench suite."""
 
 import logging
+from functools import cached_property
 from typing import Any
 
 from inspect_ai.log import (
@@ -217,3 +218,54 @@ def process_eval_logs(
         )
 
     return EvalLogProcessingResult(results=results, errors=errors)
+
+
+class TaskResults(BaseModel):
+    """Scores for all tasks in the suite"""
+
+    results: list[TaskResult]
+    cost_map_url: str | None = None
+    """URL of the litellm model pricing JSON used to compute costs.
+    Points to a specific git commit so the cost basis is exactly reproducible."""
+
+    @cached_property
+    def agent_specs(self) -> set[str]:
+        specs: set[str] = set()
+        for task_result in self.results or []:
+            if task_result.eval_spec:
+                agent_spec = task_result.eval_spec.model_dump_json(
+                    include={"solver", "solver_args", "model", "model_args"}
+                )
+                specs.add(agent_spec)
+        return specs
+
+    @cached_property
+    def code_specs(self) -> set[str]:
+        specs: set[str] = set()
+        for task_result in self.results or []:
+            if task_result.eval_spec:
+                code_spec = task_result.eval_spec.model_dump_json(
+                    include={"revision", "packages"}
+                )
+                specs.add(code_spec)
+        return specs
+
+    @cached_property
+    def tasks_with_args(self) -> list[str]:
+        tasks_with_args: list[str] = []
+        for task_result in self.results or []:
+            if task_result.eval_spec and task_result.eval_spec.task_args_passed:
+                tasks_with_args.append(task_result.task_name)
+        return tasks_with_args
+
+    @cached_property
+    def task_names(self) -> set[str]:
+        """
+        Get the names of all tasks in the results.
+
+        Returns:
+            List of task names.
+        """
+        return (
+            set(result.task_name for result in self.results) if self.results else set()
+        )


### PR DESCRIPTION
## Why

`asta-bench` needs agent-eval's suite schema, `EvalConfig`, and git reproducibility check while solving, but those utilities do not use Inspect. Today agent-eval's base `inspect-ai==0.3.203` pin and eager scoring imports force solve environments down to the scorer's Inspect version. That blocks inspect-swe, whose tight runtime floor is `0.3.233`.

Tracking: allenai/gas2own#346. Consumer: allenai/asta-bench#156.

## What

- Move `inspect-ai==0.3.203` from base dependencies to a new `scoring` extra; `leaderboard` includes `scoring`.
- Make package-level scoring exports lazy so `import agenteval` and inspect-free submodules do not import Inspect.
- Keep `EvalConfig`/submission models inspect-free; retain lazy compatibility aliases for `TaskResult`/`TaskResults`.
- Move `verify_git_reproducibility` from inspect-bound `cli.py` to inspect-free `io.py`.
- Declare the existing YAML runtime dependency explicitly.
- Release the contract as `0.1.52`.

The scoring behavior and scorer pin remain unchanged at Inspect `0.3.203`.

## Validation

All CI is green:

- base install proves `agenteval`, config, `EvalConfig`, and io/repro helpers import and round-trip with no `inspect_ai` installed;
- core and leaderboard suites pass with their scoring dependencies;
- schema validation and GitGuardian pass.

## Merge order

Merge and publish/tag agent-eval `0.1.52` first. asta-bench#156 is currently tested against this PR's exact commit; its temporary `[tool.uv.sources]` override should then be removed before that PR merges.
